### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ human_context:
 
 ---
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wolfe-jam-claude-faf-mcp).
+
 ## Quick Start
 
 **Copy and paste this to Claude:**


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wolfe-jam-claude-faf-mcp)