### PR TITLE
ci: remove npm publish step — stop the red-badge race with /pubpro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,44 +165,6 @@ jobs:
           echo "Directory operations: <30ms ✅"
           echo "Format operations: <1ms ✅"
 
-  # 📦 Publish (only on release)
-  publish:
-    name: 📦 Publish to NPM
-    runs-on: ubuntu-latest
-    needs: [build, performance]
-    if: github.event_name == 'release'
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build
-        run: npm run build
-
-      - name: Publish to NPM
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Create GitHub Release Assets
-        run: |
-          npm pack
-          mv *.tgz faf-mcp-${{ github.event.release.tag_name }}.tgz
-
-      - name: Upload Release Asset
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} faf-mcp-${{ github.event.release.tag_name }}.tgz --clobber
-
   # 🏆 Championship Status
   status:
     name: 🏆 Championship Status


### PR DESCRIPTION
## Summary
- Deletes the `📦 Publish to NPM` job from `.github/workflows/ci.yml`
- `/pubpro` is the single source of truth for publishing; CI should only validate
- Fixes the recurring red CI badge on [npmjs.com/package/claude-faf-mcp](https://www.npmjs.com/package/claude-faf-mcp)

## Root cause
CI's publish step fires on `release` events and races `/pubpro`'s manual `npm publish`. Because pubpro ships first, CI hits:

```
npm error 404 'claude-faf-mcp@5.5.1' is not in this registry.
```

…and the badge flips red even though the package published fine. Seen on the v5.5.1 release: [run 24639634486](https://github.com/Wolfe-Jam/claude-faf-mcp/actions/runs/24639634486).

## Test plan
- [ ] Merge → next push to `main` runs CI without the publish job
- [ ] Badge on npmjs.com turns green on the following render
- [ ] Confirm `/pubpro` publish flow still works end-to-end on the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)