### PR TITLE
Add citation infra: both FAF papers (Context + Memory)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,47 @@
+cff-version: 1.2.0
+type: software
+message: "If you use claude-faf-mcp or the .faf / .fafm formats in your work, please cite the format papers in `preferred-citation` and `references` below."
+title: "claude-faf-mcp — Claude Desktop MCP server for .faf and .fafm IANA-registered formats"
+authors:
+  - family-names: Wolfe
+    given-names: James
+    orcid: "https://orcid.org/0009-0007-0801-3841"
+    affiliation: "FAF Foundation"
+license: MIT
+repository-code: "https://github.com/Wolfe-Jam/claude-faf-mcp"
+url: "https://faf.one"
+keywords:
+  - .faf
+  - .fafm
+  - MCP
+  - Model Context Protocol
+  - Claude Desktop
+  - IANA-registered format
+preferred-citation:
+  type: article
+  title: "Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding"
+  authors:
+    - family-names: Wolfe
+      given-names: James
+      orcid: "https://orcid.org/0009-0007-0801-3841"
+      affiliation: "FAF Foundation"
+  year: 2025
+  month: 11
+  doi: 10.5281/zenodo.18251362
+  url: "https://doi.org/10.5281/zenodo.18251362"
+  publisher:
+    name: "Zenodo"
+references:
+  - type: article
+    title: "Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory"
+    authors:
+      - family-names: Wolfe
+        given-names: James
+        orcid: "https://orcid.org/0009-0007-0801-3841"
+        affiliation: "FAF Foundation"
+    year: 2026
+    month: 5
+    doi: 10.5281/zenodo.20348942
+    url: "https://doi.org/10.5281/zenodo.20348942"
+    publisher:
+      name: "Zenodo"

--- a/README.md
+++ b/README.md
@@ -295,3 +295,38 @@ npx faf-cli auto
 ```
 
 **Anthropic MCP [#2759](https://github.com/modelcontextprotocol/servers/pull/2759)** · **2 IANA registrations:** `vnd.faf+yaml` (Context) · `vnd.fafm+yaml` (Memory) · [faf.one](https://faf.one) · [npm](https://www.npmjs.com/package/faf-cli)
+
+## Citation
+
+If you use `.faf` (and/or `.fafm`) in research or production, please cite the format papers:
+
+> Wolfe, J. (2025). *Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding*. Zenodo. https://doi.org/10.5281/zenodo.18251362
+
+> Wolfe, J. (2026). *Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory*. Zenodo. https://doi.org/10.5281/zenodo.20348942
+
+### BibTeX
+
+```bibtex
+@article{wolfe2025faf,
+  title     = {Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding},
+  author    = {Wolfe, James},
+  year      = {2025},
+  month     = {nov},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.18251362},
+  url       = {https://doi.org/10.5281/zenodo.18251362}
+}
+
+@article{wolfe2026fafm,
+  title     = {Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory},
+  author    = {Wolfe, James},
+  year      = {2026},
+  month     = {may},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20348942},
+  url       = {https://doi.org/10.5281/zenodo.20348942}
+}
+```
+
+[![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
+


### PR DESCRIPTION
## Summary

claude-faf-mcp already acknowledges both IANA-registered formats throughout the README but had no citation infrastructure for the format papers. This PR:

- **Adds CITATION.cff** (CFF 1.2.0) — `preferred-citation` = Context paper (foundational); `references` += Memory paper (.fafm).
- **Adds ## Citation section** with both papers + BibTeX + Option-1 orange DOI badges side-by-side.

Companion to:
- Wolfe-Jam/faf#10 (in flight)
- Wolfe-Jam/grok-faf-voice#1 + #3 (merged)
- Wolfe-Jam/claude-fafm-sdk#1 + #2 (merged)
- Wolfe-Jam/faf-cli (parallel PR opened today)

## Receipts

- Context paper: DOI `10.5281/zenodo.18251362` (Zenodo, Nov 2025)
- Memory paper: DOI `10.5281/zenodo.20348942` (Zenodo, May 2026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)