### PR TITLE
Master template: cohort credibility badges + citation infra

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,47 @@
+cff-version: 1.2.0
+type: software
+message: "If you use claude-faf-mcp or the .faf / .fafm IANA-registered formats in your work, please cite the format papers in `preferred-citation` and `references` below."
+title: "claude-faf-mcp — Claude Desktop MCP server for .faf and .fafm IANA-registered formats"
+authors:
+  - family-names: Wolfe
+    given-names: James
+    orcid: "https://orcid.org/0009-0007-0801-3841"
+    affiliation: "FAF Foundation"
+license: MIT
+repository-code: "https://github.com/Wolfe-Jam/claude-faf-mcp"
+url: "https://faf.one"
+keywords:
+  - .faf
+  - .fafm
+  - MCP
+  - Model Context Protocol
+  - Claude Desktop
+  - IANA-registered format
+preferred-citation:
+  type: article
+  title: "Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding"
+  authors:
+    - family-names: Wolfe
+      given-names: James
+      orcid: "https://orcid.org/0009-0007-0801-3841"
+      affiliation: "FAF Foundation"
+  year: 2025
+  month: 11
+  doi: 10.5281/zenodo.18251362
+  url: "https://doi.org/10.5281/zenodo.18251362"
+  publisher:
+    name: "Zenodo"
+references:
+  - type: article
+    title: "Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory"
+    authors:
+      - family-names: Wolfe
+        given-names: James
+        orcid: "https://orcid.org/0009-0007-0801-3841"
+        affiliation: "FAF Foundation"
+    year: 2026
+    month: 5
+    doi: 10.5281/zenodo.20348942
+    url: "https://doi.org/10.5281/zenodo.20348942"
+    publisher:
+      name: "Zenodo"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 # claude-faf-mcp
 
+[![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
+[![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
+
+
 **Persistent Project Context for Claude. 30 seconds. 🐘 It never forgets.**
 
 [![FAF](https://mcpaas.live/badge/Wolfe-Jam/claude-faf-mcp.svg)](https://builder.faf.one)
@@ -260,6 +264,39 @@ Everything runs locally. No data leaves your machine. No analytics, no telemetry
 If `claude-faf-mcp` has been useful, consider starring the repo — it helps others find it.
 
 ---
+
+
+## Citation
+
+If you use `claude-faf-mcp` or the `.faf` / `.fafm` formats in research or production, please cite the format papers:
+
+> Wolfe, J. (2025). *Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding*. Zenodo. https://doi.org/10.5281/zenodo.18251362
+
+> Wolfe, J. (2026). *Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory*. Zenodo. https://doi.org/10.5281/zenodo.20348942
+
+### BibTeX
+
+```bibtex
+@article{wolfe2025faf,
+  title     = {Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding},
+  author    = {Wolfe, James},
+  year      = {2025},
+  month     = {nov},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.18251362},
+  url       = {https://doi.org/10.5281/zenodo.18251362}
+}
+
+@article{wolfe2026fafm,
+  title     = {Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory},
+  author    = {Wolfe, James},
+  year      = {2026},
+  month     = {may},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20348942},
+  url       = {https://doi.org/10.5281/zenodo.20348942}
+}
+```
 
 ## License
 


### PR DESCRIPTION
Applies the master template cohort credibility badges + citation infrastructure locked on Wolfe-Jam/faf#10.

**Both-formats class** — 2+2 cohort badges at top:
`[IANA: vnd.faf+yaml][IANA: vnd.fafm+yaml]`
`[DOI: Context paper][DOI: Memory paper]`

Plus:
- New `CITATION.cff` (CFF 1.2.0) — `preferred-citation` = Context paper, `references` += Memory paper.
- New `## Citation` section with both papers + BibTeX.

Per `feedback-update-via-repos-canonical-channel` doctrine — same canonical pattern across all FAF cohort repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)