### PR TITLE
ci: make Claude Code Review job non-blocking

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Advisory PR-review job is failing fleet-wide on an upstream bug in `anthropics/claude-code-action@v1` (`directory mismatch / tsconfig.json`). A review assistant crashing must not red-badge PRs. Adds `continue-on-error: true` to the `claude-review` job — stops the red-X noise, self-heals when upstream v1 is fixed, resilient to future upstream bugs. CI-only, one line. Matches the no-red-X-noise doctrine.