### PR TITLE
fix: memoize CLI detection (kills redundant execs + Windows teardown flake)

### DIFF
--- a/src/utils/cli-detector.ts
+++ b/src/utils/cli-detector.ts
@@ -141,9 +141,27 @@ function getCliVersion(cliPath: string): string | undefined {
 }
 
 /**
- * Detect faf CLI location with multiple fallback strategies
+ * Detect faf CLI location with multiple fallback strategies.
+ *
+ * Memoized: detection is deterministic per process (the CLI path/version
+ * don't change mid-run), so the underlying execSync probes run ONCE and
+ * the result is reused. This eliminates redundant child-process spawns
+ * across many FafEngineAdapter instantiations — and the intermittent
+ * Windows "worker failed to exit gracefully" Jest teardown leak that
+ * the per-instance re-probing caused.
+ *
+ * @param forceRefresh re-probe and refresh the cache (used by tests).
  */
-export function detectFafCli(): CliDetectionResult {
+let _detectionCache: CliDetectionResult | null = null;
+export function detectFafCli(forceRefresh = false): CliDetectionResult {
+  if (_detectionCache && !forceRefresh) {
+    return _detectionCache;
+  }
+  _detectionCache = detectFafCliInternal();
+  return _detectionCache;
+}
+
+function detectFafCliInternal(): CliDetectionResult {
   // 1. Check environment variable override
   if (process.env.FAF_CLI_PATH) {
     const envPath = process.env.FAF_CLI_PATH;


### PR DESCRIPTION
Final repo in the 3-way fan-out — same root fix as [faf-mcp#41](https://github.com/Wolfe-Jam/faf-mcp/pull/41) and [grok-faf-mcp#53](https://github.com/Wolfe-Jam/grok-faf-mcp/pull/53). Memoizes `detectFafCli()` so the `execSync` CLI probes run once per process instead of per-`FafEngineAdapter` (~20-30 spawns/run → 2-3), removing the intermittent Windows 'worker failed to exit' teardown flake. Deterministic per process; optional `forceRefresh` for tests. Real fix + perf win, not `--forceExit`. Authorized per repo code-change protocol.