### PR TITLE
ci: forceExit in jest config (clean worker exit on benign lingering handles)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,4 +30,9 @@ module.exports = {
       },
     },
   },
+  // Tests pass cleanly, but benign exec/server handles can linger past the
+  // worker's exit check on CI runners (Windows/macOS), force-exiting a worker
+  // non-zero. Not a test failure — Jest's documented finish for lingering
+  // resources. Pairs with the memoized CLI detection (fewer handles).
+  forceExit: true,
 };


### PR DESCRIPTION
Completes the teardown-flake fix (pairs with the memoized CLI detection #56). CI intermittently red-failed *passing* suites via Jest's 'worker failed to exit gracefully' (exit 1), attributed to a random suite each run — teardown timing, not a real assertion (381 always pass). `forceExit: true` is Jest's documented finish for benign lingering resources; grok-faf-mcp already had it. Not masking — no failing test exists. Authorized per fleet-wide forceExit go.