### PR TITLE
fix(ci): run tests in-band + fix the cwd-isolation bug it surfaced

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,9 +30,10 @@ module.exports = {
       },
     },
   },
-  // Tests pass cleanly, but benign exec/server handles can linger past the
-  // worker's exit check on CI runners (Windows/macOS), force-exiting a worker
-  // non-zero. Not a test failure — Jest's documented finish for lingering
-  // resources. Pairs with the memoized CLI detection (fewer handles).
-  forceExit: true,
+  // Tests run in-band (package.json `test` → `jest --runInBand`). Serial
+  // execution removes Jest's worker pool — the source of the intermittent
+  // "worker failed to exit gracefully" red on constrained Windows/macOS CI
+  // runners. In-band exits clean on its own (--detectOpenHandles reports ZERO
+  // open handles), so no forceExit is needed — and forceExit was suppressing
+  // that very diagnostic.
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev": "ts-node src/server.ts",
     "dev:stdio": "ts-node src/cli.ts --transport stdio",
     "dev:http": "ts-node src/cli.ts --transport http-sse --port 3001",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:performance": "jest tests/performance.test.ts --testPathIgnorePatterns=/node_modules/",
     "test:mcp": "mcp-inspector stdio ts-node src/cli.ts",
     "lint": "eslint src/**/*.ts",

--- a/tests/desktop-native-validation.test.ts
+++ b/tests/desktop-native-validation.test.ts
@@ -19,11 +19,13 @@ const getTextContent = (content: unknown[]): string =>
 
 describe('🏁 Desktop-Native MCP Championship Tests', () => {
   let testDir: string;
+  let originalCwd: string;
 
   beforeAll(async () => {
     // Create isolated test environment
     testDir = path.join('/tmp', `faf-desktop-test-${Date.now()}`);
     fs.mkdirSync(testDir, { recursive: true });
+    originalCwd = process.cwd();
     process.chdir(testDir);
 
     // Initialize server WITHOUT CLI (for validation but not used in tests)
@@ -35,8 +37,10 @@ describe('🏁 Desktop-Native MCP Championship Tests', () => {
   });
   
   afterAll(async () => {
-    // Cleanup
-    process.chdir('/');
+    // Restore the original cwd — chdir('/') here polluted cwd for later
+    // suites in single-process runs (in-band / bun), breaking cwd-relative
+    // tests (human-context, readme-extraction) and the security path check.
+    process.chdir(originalCwd);
     fs.rmSync(testDir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
Mirror of faf-mcp #43 / grok #54 (both CI-green incl. Windows), plus the real fix.

**Root cause:** the intermittent "worker failed to exit gracefully" red is a Jest worker-pool shutdown race, not an open-handle leak (`--detectOpenHandles` = zero handles). In-band removes the worker pool → the class can't occur.

**Real bug surfaced:** in-band exposed a pre-existing cwd-isolation bug the worker pool was hiding — `desktop-native`'s `afterAll` did `chdir('/')` without restoring cwd, breaking cwd-relative suites (`human-context`, `readme-extraction`): 39 failures in single-process. Fixed by restoring `originalCwd`. (Same class fixed grok's Windows security regression; required for the bun migration too.)

Local: 381/381 in-band, exit 0, no worker warning. CI here is the proof.