### PR TITLE
fix(score): wire faf_score through faf-cli's scoreFafYaml — v5.6.1 (shield loop closing, Case A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ All notable changes to claude-faf-mcp will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [5.6.1] - 2026-05-26
+
+Loop closed on truthful, single-sourced scoring. The active MCP handler
+now reads faf-cli's real scorer directly — same path the championship
+layer was already on, same number `faf score` (CLI) and faf-mcp 2.1.1 emit.
+
+### Fixed
+
+- **`faf_score`** — now calls faf-cli's `scoreFafYaml` (the IANA-spec
+  scorer) directly, replacing the FafCompiler-based path. Output
+  reformatted to the canonical tier card with `FAF SCORE: <n>/100 (<n>%)`,
+  progress bar, populated/total slot count, and the next-tier hint. The
+  banned medal / colored-circle tier ladder (🥇🥈🥉🟢🟡🔴🤍) is gone from
+  this surface — only canonical Unicode tier glyphs (★ ◆ ◇ ● ○ ♡) remain.
+- **Invalid `.faf` handling** — `0/100 (0%) ○ INVALID` for parse failures,
+  `○ UNREADABLE` for fs errors, `♡ no .faf` for absence. Honest zero with
+  a diagnostic, never a fake score, never a crash.
+
+### Tests
+
+- **WJTTC AERO Phase 2** — score-parity assertion tightened to TRUE
+  parity: MCP `faf_score` numeric == faf-cli `scoreFafYaml(...).score`
+  on the same YAML. Determinism + repeatability tests retained as
+  high-signal companions; FINDING comment retensed from v5.6.0
+  observation → v5.6.1 resolved.
+
 ## [5.6.0] - 2026-05-25
 
 🏆 **FAF-binary scoring lands in Claude Desktop.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-faf-mcp",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "mcpName": "io.github.Wolfe-Jam/claude-faf-mcp",
   "description": "Persistent Project Context for Claude. IANA-registered .faf format, 33 MCP tools, 391 tests.",
   "icon": "./assets/icons/faf-icon-256.png",

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -11,6 +11,10 @@ import { resolveProjectPath, formatPathConfirmation } from '../utils/path-resolv
 import { resolveMemoryPath, memoryExport, getMemoryStatus } from '../utils/memory-parser';
 import { FafCompiler } from '../faf-core/compiler/faf-compiler.js';
 
+// Truthful single-source FAF score wiring — see src/utils/faf-cli-bridge.ts
+// for why this exists (faf-cli's bun exports condition + Node 18 ESM-from-CJS).
+import { fafCli } from '../utils/faf-cli-bridge.js';
+
 export class FafToolHandler {
   constructor(private engineAdapter: FafEngineAdapter) {}
 
@@ -864,115 +868,123 @@ Once confirmed, the sequence is:
   }
 
   private async handleFafScore(args: any): Promise<CallToolResult> {
-    try {
-      // Get current working directory - uses path param or session context
-      const cwd = this.getProjectPath(args?.path);
+    // v5.6.1: single-sourced from faf-cli's real scorer — same number `faf
+    // score` (CLI), the championship handler, and faf-mcp 2.1.1 all emit.
+    // The old FafCompiler-based path + banned medal/colored-circle tier
+    // ladder (🥇🥈🥉🟢🟡🔴🤍) are retired on the live handler. Mirrors
+    // faf-mcp PR #48 surgical fix verbatim.
+    // Headline format carries both `FAF SCORE: <n>/100` AND `(<n>%)` so the
+    // AERO parity regex AND any consumer scanning for the legacy `\d+%`
+    // form continue to match. Invalid/unreadable .faf paths return an
+    // honest `0/100 (0%)` with a diagnostic — no fake numbers, no crash.
+    const cwd = this.getProjectPath(args?.path);
+    const { findFafFile, readFafRaw, scoreFafYaml, getNextTier } = await fafCli;
 
-      // Find FAF file
-      const fafResult = await findFafFile(cwd);
-      if (!fafResult) {
-        return {
-          content: [{
+    const fafPath = findFafFile(cwd);
+    if (!fafPath) {
+      return {
+        content: [
+          {
             type: 'text',
-            text: `📊 FAF SCORE: 0%\n🤍 White\n🏁 AI-Ready: Building\n\n❌ No project.faf found in ${cwd}\n💡 Run faf_init to create project DNA for accurate scoring!`
-          }]
-        };
-      }
-
-      // Use FafCompiler for precise slot-based scoring
-      const compiler = new FafCompiler();
-      const compileResult = await compiler.compile(fafResult.path);
-
-      const score = Math.min(compileResult.score, 100);
-      const filled = compileResult.filled;
-      const total = compileResult.total;
-      const breakdown = compileResult.breakdown;
-
-      // Format the output
-      let output = '';
-
-      if (score >= 100) {
-        // Perfect score - Trophy
-        output = `🏎️ FAF SCORE: 100%\n🏆 Trophy\n🏁 Championship Complete!\n\n`;
-        if (args?.details) {
-          output += `✅ ${fafResult.filename} analyzed (${filled}/${total} slots filled)\n\n`;
-          output += `🏆 PERFECT SCORE!\n`;
-          output += `All slots filled - championship AI-readiness achieved!\n`;
-          output += `\n💡 Note: 🍊 Big Orange is a BADGE awarded separately for excellence beyond metrics.`;
-        }
-      } else {
-        // Regular score - FAF standard tiers
-        let rating = '';
-        let emoji = '';
-
-        if (score >= 99) {
-          rating = 'Gold';
-          emoji = '🥇';
-        } else if (score >= 95) {
-          rating = 'Silver';
-          emoji = '🥈';
-        } else if (score >= 85) {
-          rating = 'Bronze';
-          emoji = '🥉';
-        } else if (score >= 70) {
-          rating = 'Green';
-          emoji = '🟢';
-        } else if (score >= 55) {
-          rating = 'Yellow';
-          emoji = '🟡';
-        } else {
-          rating = 'Red';
-          emoji = '🔴';
-        }
-
-        // Next milestone (matches faf-cli score-v3)
-        const milestones = [
-          { target: 55, tier: 'Yellow', emoji: '🟡' },
-          { target: 70, tier: 'Green', emoji: '🟢' },
-          { target: 85, tier: 'Bronze', emoji: '🥉' },
-          { target: 95, tier: 'Silver', emoji: '🥈' },
-          { target: 99, tier: 'Gold', emoji: '🥇' },
-          { target: 100, tier: 'Trophy', emoji: '🏆' },
-        ];
-        const next = milestones.find(m => m.target > score);
-
-        // The 3-line killer display
-        output = `📊 FAF SCORE: ${score}%\n${emoji} ${rating}\n🏁 AI-Ready: ${score >= 85 ? 'Yes' : 'Building'}\n`;
-
-        if (next) {
-          output += `\nNext milestone: ${next.target}% ${next.emoji} ${next.tier} (${next.target - score} points to go!)`;
-        }
-
-        if (args?.details) {
-          // Section breakdown (matches faf-cli --breakdown)
-          output += `\n\n📊 Score Breakdown:`;
-          output += `\n  Project: ${breakdown.project.filled}/${breakdown.project.total} slots (${breakdown.project.percentage}%)`;
-          output += `\n  Stack:   ${breakdown.stack.filled}/${breakdown.stack.total} slots (${breakdown.stack.percentage}%)`;
-          output += `\n  Human:   ${breakdown.human.filled}/${breakdown.human.total} slots (${breakdown.human.percentage}%)`;
-          if (breakdown.discovery.total > 0) {
-            output += `\n  Discovery: ${breakdown.discovery.filled}/${breakdown.discovery.total} slots (${breakdown.discovery.percentage}%)`;
-          }
-          output += `\n\nFilled: ${filled}/${total} slots`;
-        }
-      }
-
-      return {
-        content: [{
-          type: 'text',
-          text: output
-        }]
-      };
-
-    } catch (error: any) {
-      // Real error — never fake a score (matches faf-cli behavior)
-      const message = error instanceof Error ? error.message : String(error);
-      return {
-        content: [{
-          type: 'text',
-          text: `📊 FAF SCORE: Error\n\n❌ Compilation failed: ${message}\n💡 Run faf_init to create a valid project.faf`
-        }]
+            text:
+              `FAF SCORE: 0/100 (0%)  ♡ no .faf\n\n` +
+              `No \`.faf\` found in \`${cwd}\`.\n` +
+              `Run \`faf_init\` to create one — then \`faf_score\` reports the real score.`,
+          },
+        ],
       };
     }
+
+    // Strip ANSI from tier indicator (faf-cli emits colored glyphs).
+    // eslint-disable-next-line no-control-regex
+    const strip = (s: string): string => s.replace(/\[[0-9;]*m/g, '').trim();
+
+    let raw: string;
+    try {
+      raw = readFafRaw(fafPath);
+    } catch (error: any) {
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `FAF SCORE: 0/100 (0%)  ○ UNREADABLE\n\n` +
+              `Could not read \`${fafPath}\`: ${error?.message ?? String(error)}`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    let result: ReturnType<Awaited<typeof fafCli>['scoreFafYaml']>;
+    try {
+      result = scoreFafYaml(raw);
+    } catch (error: any) {
+      // Invalid .faf content (malformed YAML, etc.) — honest 0 score with a
+      // diagnostic, not a fake number. The output still carries `0%` so
+      // downstream regex matchers like `/\d+%/` find a percentage token.
+      return {
+        content: [
+          {
+            type: 'text',
+            text:
+              `FAF SCORE: 0/100 (0%)  ○ INVALID\n\n` +
+              `\`${fafPath}\` couldn\'t be parsed as a valid .faf YAML:\n` +
+              `  ${error?.message ?? String(error)}\n\n` +
+              `Re-run \`faf_init\` to regenerate a valid file.`,
+          },
+        ],
+        isError: true,
+      };
+    }
+
+    const score = result.score;
+    const tierDisplay = strip(result.tier.indicator);
+    const next = getNextTier(score);
+    const nextTierDisplay = next ? `${strip(next.indicator)} (${next.threshold}%)` : null;
+
+    // Progress bar — same width/style as the championship handler.
+    const barWidth = 24;
+    const filled = Math.max(0, Math.min(barWidth, Math.round((score / 100) * barWidth)));
+    const progressBar = '█'.repeat(filled) + '░'.repeat(barWidth - filled);
+
+    // Headline carries both `/100` AND `(%)` so multiple matchers stay happy.
+    let output =
+      `FAF SCORE: ${score}/100 (${score}%)  ${tierDisplay}\n` +
+      `${progressBar} ${score}%\n` +
+      `${result.populated}/${result.total} slots populated` +
+      (nextTierDisplay ? `  ·  next: ${nextTierDisplay}` : '  ·  top tier') +
+      `\n\n` +
+      `Scored by faf-cli — the same context your AI reads.`;
+
+    if (args?.details) {
+      const populatedSlots = Object.entries(result.slots)
+        .filter(([, state]) => state === 'populated')
+        .map(([slot]) => slot);
+      const emptySlots = Object.entries(result.slots)
+        .filter(([, state]) => state === 'empty')
+        .map(([slot]) => slot);
+      const ignoredSlots = Object.entries(result.slots)
+        .filter(([, state]) => state === 'slotignored')
+        .map(([slot]) => slot);
+
+      output += `\n\n--- Slot breakdown ---\n`;
+      output += `Populated (${populatedSlots.length}): ${populatedSlots.join(', ') || '(none)'}\n`;
+      output += `Empty (${emptySlots.length}): ${emptySlots.join(', ') || '(none)'}\n`;
+      output += `Ignored (${ignoredSlots.length}): ${ignoredSlots.join(', ') || '(none)'}`;
+      if (score < 100 && emptySlots.length > 0) {
+        output += `\n\nTip: fill empty slots or mark them \`slotignored\` to climb tiers. Slot-by-slot detail: \`faf score\` (CLI).`;
+      }
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: output,
+        },
+      ],
+    };
   }
 
   private async handleFafInit(args: any): Promise<CallToolResult> {

--- a/src/utils/faf-cli-bridge.ts
+++ b/src/utils/faf-cli-bridge.ts
@@ -1,0 +1,69 @@
+/**
+ * faf-cli bridge — single re-export point for faf-cli's typed public API.
+ *
+ * Why this file exists (three coupled problems):
+ *   1. faf-cli 6.7.1's `exports` map sets a `bun` condition pointing at a
+ *      non-shipped `src/index.ts`. Bun's resolver always picks the `bun`
+ *      condition first (verified: `--conditions=node` ADDS to the set,
+ *      doesn't replace), so `from 'faf-cli'` blows up at module-load in
+ *      bun-test. Subpath imports (`faf-cli/dist/index.js`) are ALSO blocked
+ *      because faf-cli's exports map only exports `.`.
+ *   2. Static relative paths don't survive tsc compilation: a literal
+ *      `../../node_modules/...` written in `src/utils/` resolves to the
+ *      wrong place when the compiled file lands at `dist/src/utils/` (one
+ *      level deeper, so the relative escape comes up short).
+ *   3. faf-cli's dist is ESM (`"type": "module"`). Node 18 rejects sync
+ *      `require()` of ESM (`ERR_REQUIRE_ESM`); Node 20 allows it. faf-mcp
+ *      supports Node 18+ per `engines`, so we must use dynamic `import()`.
+ *
+ * How this bridge works:
+ *   At runtime, walk upward from `__dirname` (which is `src/utils/` when
+ *   bun loads TS source and `dist/src/utils/` when Node loads compiled
+ *   CJS) until we find `node_modules/faf-cli/dist/index.js`. Then load it
+ *   via dynamic `import()` of an absolute `file://` URL — which:
+ *     - bypasses the exports map (no package specifier, no condition picked)
+ *     - handles ESM-from-CJS correctly on Node 18+ AND in bun
+ *     - resolves the same module regardless of source-vs-compiled __dirname
+ *
+ *   The type info comes via `import type` — purely compile-time, esbuild
+ *   strips it at load time, so the `bun` condition never fires for types.
+ *
+ *   Export shape: `fafCli` is a Promise<typeof FafCli>. Consumers
+ *   destructure with `const { ... } = await fafCli` inside async handlers.
+ *   Module evaluation is one-shot — the Promise is created at module load
+ *   and cached forever.
+ *
+ *   This is intentionally a TEMPORARY workaround tied to faf-cli's bun
+ *   exports bug. Once faf-cli ships `src/` OR drops the `bun` condition,
+ *   this whole file becomes `export * from 'faf-cli'` and consumers go
+ *   back to bare specifiers. Tracked alongside the AERO test's matching
+ *   workaround comment in tests/wjttc-bun.test.ts.
+ *
+ *   Doctrine: silent-drift = fail = forbidden. The bridge is loud and
+ *   localized — one file, fully commented — not scattered ts-ignores or
+ *   silent type-casts.
+ */
+
+import * as path from 'path';
+import * as fs from 'fs';
+import { pathToFileURL } from 'url';
+import type * as FafCli from 'faf-cli';
+
+function findFafCliDist(startDir: string): string {
+  let dir = startDir;
+  while (dir !== path.dirname(dir)) {
+    const candidate = path.join(dir, 'node_modules', 'faf-cli', 'dist', 'index.js');
+    if (fs.existsSync(candidate)) return candidate;
+    dir = path.dirname(dir);
+  }
+  throw new Error(
+    `faf-cli/dist/index.js not found in any ancestor node_modules of ${startDir}. ` +
+      `faf-mcp requires faf-cli as a direct dependency — check installation.`,
+  );
+}
+
+// Cached promise — module evaluation happens once.
+export const fafCli: Promise<typeof FafCli> = (async () => {
+  const distPath = findFafCliDist(__dirname);
+  return (await import(pathToFileURL(distPath).href)) as typeof FafCli;
+})();

--- a/tests/wjttc-bun.test.ts
+++ b/tests/wjttc-bun.test.ts
@@ -293,29 +293,27 @@ describe('🏁 WJTTC — bun migration + MCP integrity (claude-faf-mcp)', () => 
     // INTENT (per the task brief): assert MCP `faf_score` text-score equals
     // faf-cli's `scoreFafYaml(...).score` on the same YAML.
     //
-    // OBSERVED v5.6.0 (logged + asserted, not hidden): the active
-    // FafToolHandler (src/handlers/tools.ts, the one server.ts L64 actually
-    // wires up via `new FafToolHandler(engineAdapter)`) uses the OLD
-    // file-presence pseudo-score in handleFafScore. The truthful
-    // single-sourced scorer that imports `scoreFafYaml` lives in
-    // ChampionshipToolHandler (championship-tools.ts L25-30 + handleScore at
-    // L~135) — present in the repo (2616 lines, real implementation) but
-    // NOT wired into the MCP server. So MCP `faf_score` and `scoreFafYaml`
-    // are mathematically DIFFERENT functions today; demanding strict
-    // equality would be a guaranteed (and misleading) red.
+    // HISTORY: v5.6.0 observation logged here was — the active FafToolHandler
+    // (src/handlers/tools.ts, wired by server.ts L64) used a FafCompiler-based
+    // pseudo-score path + banned medal/colored-circle tier ladder
+    // (🥇🥈🥉🟢🟡🔴🤍), while ChampionshipToolHandler (championship-tools.ts,
+    // present but not wired) already had the truthful `scoreFafYaml` import.
+    // Same shape as faf-mcp pilot PR #47 (Case A).
     //
-    // Same shape as sibling faf-mcp pilot PR #47 (Case A: Championship
-    // exists-but-unwired). Different from sibling grok-faf-mcp PR #57
-    // (Case B: Championship doesn't exist at all in that repo). Remediation
-    // cost for claude is the same as faf-mcp: wire-up swap in server.ts.
+    // ✅ RESOLVED v5.6.1 (this PR): `FafToolHandler.handleFafScore` (the wired
+    // one) now calls faf-cli's `scoreFafYaml` directly — same single-source
+    // path the championship handler was already on, same path faf-mcp 2.1.1
+    // shipped via PR #48. The banned emoji ladder is gone; output now uses
+    // canonical Unicode tier glyphs. Parity now holds for valid `.faf` inputs;
+    // invalid/unreadable paths return `0/100 (0%)` honestly (not a fake score).
     //
-    // What we assert instead — and what's still high-signal:
+    // What we assert (all three remain high-signal):
     //   a) faf-cli's `scoreFafYaml` is reachable, deterministic, and produces
     //      a sane score on the fixture (>0 <100, repeatable).
     //   b) MCP `faf_score` returns a parseable percentage and is consistent
     //      across two calls on identical state (no flap, no nondeterminism).
-    //   c) Both are well-formed numbers in [0,100]. We do NOT assert equality.
-    //      The divergence is the test's finding — see report.
+    //   c) TRUE PARITY — MCP `faf_score` numeric == faf-cli
+    //      `scoreFafYaml(yaml).score` on the same fixture. The shield closes.
     describe('2. score determinism (single-source via faf-cli)', () => {
       test('faf-cli scoreFafYaml is deterministic on the fixture (>0, <100)', () => {
         const raw = fs.readFileSync(path.join(tmpDir, 'project.faf'), 'utf-8');
@@ -356,6 +354,28 @@ describe('🏁 WJTTC — bun migration + MCP integrity (claude-faf-mcp)', () => 
         expect(n1).toBe(n2); // repeatability
         expect(n1).toBeGreaterThanOrEqual(0);
         expect(n1).toBeLessThanOrEqual(100);
+      });
+
+      test('TRUE PARITY: MCP faf_score == faf-cli scoreFafYaml on the same YAML', async () => {
+        // The loop-closing receipt. v5.6.1 wires `handleFafScore` through
+        // faf-cli's real scorer — so the number MCP emits MUST equal the
+        // number `scoreFafYaml` returns. Single source of truth, no drift.
+        const raw = fs.readFileSync(path.join(tmpDir, 'project.faf'), 'utf-8');
+        const parityScore = fafCli.scoreFafYaml(raw).score;
+
+        const res = await client.callTool({
+          name: 'faf_score',
+          arguments: { path: tmpDir },
+        });
+        expect(res.isError).toBeFalsy();
+        const text = ((res.content as Array<{ text?: string }>)[0]?.text ?? '') as string;
+
+        const SCORE_RE = /(?:FAF SCORE:\s*|\b)(\d{1,3})\s*(?:%|\/\s*100)/;
+        const m = text.match(SCORE_RE);
+        expect(m).not.toBeNull();
+        const mcpScore = parseInt(m![1], 10);
+
+        expect(mcpScore).toBe(parityScore);
       });
     });
 

--- a/tests/wjttc-compiler-scoring.test.ts
+++ b/tests/wjttc-compiler-scoring.test.ts
@@ -421,7 +421,7 @@ describe('Tier 5: Roundtrip — faf_score MCP tool end-to-end', () => {
     const result = await handler.callTool('faf_score', { path: toolTestDir });
     const text = getTextContent(result.content);
     expect(text).toContain('FAF SCORE:');
-    expect(text).toMatch(/FAF SCORE: \d+%/);
+    expect(text).toMatch(/FAF SCORE: \d+\/100/);
   });
 
   test('faf_score with details shows breakdown', async () => {
@@ -433,12 +433,11 @@ describe('Tier 5: Roundtrip — faf_score MCP tool end-to-end', () => {
     const handler = new FafToolHandler(new FafEngineAdapter('native'));
     const result = await handler.callTool('faf_score', { path: toolTestDir, details: true });
     const text = getTextContent(result.content);
-    expect(text).toContain('Score Breakdown:');
-    expect(text).toContain('Project:');
-    expect(text).toContain('Stack:');
-    expect(text).toContain('Human:');
-    expect(text).toContain('Filled:');
-    expect(text).toMatch(/\d+\/\d+ slots/);
+    expect(text).toContain('--- Slot breakdown ---');
+    expect(text).toMatch(/Populated \(\d+\):/);
+    expect(text).toMatch(/Empty \(\d+\):/);
+    expect(text).toMatch(/Ignored \(\d+\):/);
+    expect(text).toMatch(/\d+\/\d+ slots populated/);
   });
 
   test('faf_score shows next milestone for non-perfect scores', async () => {
@@ -448,18 +447,17 @@ describe('Tier 5: Roundtrip — faf_score MCP tool end-to-end', () => {
     const handler = new FafToolHandler(new FafEngineAdapter('native'));
     const result = await handler.callTool('faf_score', { path: toolTestDir });
     const text = getTextContent(result.content);
-    expect(text).toContain('Next milestone:');
-    expect(text).toMatch(/\d+ points to go/);
+    expect(text).toMatch(/next: .+ \(\d+%\)/);
   });
 
-  test('faf_score with no .faf returns 0% White', async () => {
+  test('faf_score with no .faf returns 0/100 honestly', async () => {
     const emptyDir = path.join(tmpDir, 'mcp-empty-dir');
     fs.mkdirSync(emptyDir, { recursive: true });
     const handler = new FafToolHandler(new FafEngineAdapter('native'));
     const result = await handler.callTool('faf_score', { path: emptyDir });
     const text = getTextContent(result.content);
-    expect(text).toContain('FAF SCORE: 0%');
-    expect(text).toContain('White');
+    expect(text).toContain('FAF SCORE: 0/100 (0%)');
+    expect(text).toContain('no .faf');
     expect(text).not.toContain('92%');  // Must never show fake score
   });
 
@@ -475,16 +473,29 @@ describe('Tier 5: Roundtrip — faf_score MCP tool end-to-end', () => {
 
   test('faf_score 100% shows Trophy', async () => {
     // CLI type: 9 slots, project.main_language (not stack.main_language)
+    // To hit a TRUE 100% under faf-cli's scoreFafYaml, every applicable slot
+    // must be populated OR explicitly slotignored. The legacy FafCompiler-
+    // based pseudo-score returned 100% for any .faf with project basics; the
+    // truthful scorer is stricter (correctly so).
     fs.writeFileSync(path.join(toolTestDir, 'project.faf'), yaml.stringify({
-      project: { name: 'champion', goal: 'win', main_language: 'TypeScript', type: 'cli' },
+      faf_version: '3.0',
+      project: { name: 'champion', goal: 'win', main_language: 'TypeScript', type: 'cli', framework: 'native' },
+      stack: {
+        frontend: 'slotignored', css_framework: 'slotignored', ui_library: 'slotignored',
+        state_management: 'slotignored', backend: 'Node.js', api_type: 'cli', runtime: 'Node.js',
+        database: 'slotignored', connection: 'slotignored', hosting: 'local', build: 'tsc',
+        cicd: 'GitHub Actions', monorepo_tool: 'slotignored', package_manager: 'npm',
+        workspaces: 'slotignored', admin: 'slotignored', cache: 'slotignored',
+        search: 'slotignored', storage: 'slotignored',
+      },
       human_context: { who: 'a', what: 'b', why: 'c', where: 'd', when: 'e', how: 'f' }
     }));
     const handler = new FafToolHandler(new FafEngineAdapter('native'));
     const result = await handler.callTool('faf_score', { path: toolTestDir });
     const text = getTextContent(result.content);
-    expect(text).toContain('FAF SCORE: 100%');
-    expect(text).toContain('Trophy');
-    expect(text).toContain('Championship');
+    expect(text).toContain('FAF SCORE: 100/100 (100%)');
+    expect(text).toContain('TROPHY');
+    expect(text).toContain('top tier');
   });
 
   test('faf_score tier labels are correct', async () => {
@@ -496,8 +507,8 @@ describe('Tier 5: Roundtrip — faf_score MCP tool end-to-end', () => {
     const result = await handler.callTool('faf_score', { path: toolTestDir });
     const text = getTextContent(result.content);
     // Score should be low with just a name
-    expect(text).toMatch(/Red|Yellow|Green|Bronze|Silver|Gold/);
-    expect(text).toContain('AI-Ready:');
+    expect(text).toMatch(/RED|YELLOW|GREEN|BRONZE|SILVER|GOLD|TROPHY/);
+    expect(text).toContain('Scored by faf-cli');
   });
 
   test('faf_score error shows real message (not fake score)', async () => {


### PR DESCRIPTION
## Shield loop closes for claude — same surgical fix as faf-mcp 2.1.1

Mirrors **[Wolfe-Jam/faf-mcp#48](https://github.com/Wolfe-Jam/faf-mcp/pull/48)** (already merged + shipped to npm). WJTTC AERO Phase 2 caught the score-parity divergence on this repo too (PR #61, Case A); this is the wire-up that closes the loop. Going forward, claude-faf-mcp users see the truthful, IANA-spec score — not the FafCompiler pseudo-score with the banned medal ladder.

Per \`[[wjttc-purpose-find-bugs-others-dont-know]]\` framing: the shield is what users get; the catch is internal scaffolding.

| File | Why |
|---|---|
| \`src/handlers/tools.ts\` | \`handleFafScore\` rewired through faf-cli's \`scoreFafYaml\` / \`findFafFile\` / \`readFafRaw\` / \`getNextTier\`. Same proven pattern faf-mcp 2.1.1 shipped. Surface unchanged (33 tools). |
| \`src/utils/faf-cli-bridge.ts\` **(new)** | Verbatim copy of faf-mcp 2.1.1's runtime path-walker + dynamic \`import()\` bridge. Bypasses faf-cli 6.7.1's broken \`bun\` exports + Node 18 ESM-from-CJS. Temporary — removable once faf-cli #61 lands. |
| \`tests/wjttc-bun.test.ts\` | AERO score-parity FINDING comment retensed \`v5.6.0\` → \`v5.6.1 RESOLVED\`. **TRUE PARITY** assertion added (3rd assertion in the score block). |
| \`tests/wjttc-compiler-scoring.test.ts\` | 6 assertions refreshed from legacy emoji-ladder format → canonical Unicode-glyph format. 100% fixture made truly 100% (stack slots populated/slotignored). Behaviors preserved. |
| \`CHANGELOG.md\` | v5.6.1 entry — shield-framing, factual. |
| \`package.json\` | \`5.6.0\` → \`5.6.1\`. |

## Output format change (intentional, doctrine-compliant)

Old (banned medal ladder + colored circles + AI-Ready framing):
\`\`\`
📊 FAF SCORE: 92%
🥇 Gold
🏁 AI-Ready: Yes
\`\`\`

New (canonical Unicode glyphs + truthful number + progress bar + slot count):
\`\`\`
FAF SCORE: 80/100 (80%)  ● GREEN
███████████████████░░░░░ 80%
12/21 slots populated  ·  next: ◇ BRONZE (85%)

Scored by faf-cli — the same context your AI reads.
\`\`\`

## Surgical scope — what this PR is NOT

- **NOT a wholesale handler swap.** ChampionshipToolHandler (2616 lines, 55 tools) stays untouched. claude's 33-tool surface unchanged.
- **NOT a behavior-changing event for non-score tools.** Every other tool routes identically to v5.6.0.

## Tests

| Suite | Result |
|---|---|
| \`tsc --noEmit\` | 0 errors |
| AERO block (incl. TRUE PARITY) | **25/0/0** |
| Full suite | **422 pass / 1 todo / 0 fail** (1851 expects) |

## Follow-ups (tracked)

- Remove the bridge file once faf-cli #61 lands (small follow-up PR).
- After this lands + ships: \`/pubpro\` claude v5.6.1 for npm + MCP Registry.

## Test plan

- [ ] CI green across ubuntu / macOS / **windows**
- [ ] AERO TRUE PARITY passes on all three OS cells
- [ ] No regressions in existing conformance / unit tests beyond pre-existing flakes (the memory-growth flake at \`wjttc-mcp.test.ts:762\` is tracked separately as task #62)