### PR TITLE
docs: bunx config + remove broken hosted SSE install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,6 @@ human_context:
 
 ## Quick Start
 
-### Web — best of all scenarios
-
-```bash
-claude mcp add --transport http claude-faf-mcp https://claude-faf-mcp.vercel.app/sse
-```
-
-URL-based. Zero install. Always current. Works in Claude Code today.
-
 ### faf-cli — universal (any AI)
 
 ```bash
@@ -96,14 +88,14 @@ Double-click. **No terminal. No JSON config. 33 tools live in 10 seconds.**
 
 **Copy** — paste-prompt to Claude
 
-> Install the FAF MCP server: `npm install -g claude-faf-mcp`, then add this to my claude_desktop_config.json: `{"mcpServers": {"faf": {"command": "npx", "args": ["-y", "claude-faf-mcp"]}}}` and restart Claude Desktop.
+> Install the FAF MCP server: `npm install -g claude-faf-mcp`, then add this to my claude_desktop_config.json: `{"mcpServers": {"faf": {"command": "bunx", "args": ["claude-faf-mcp"]}}}` and restart Claude Desktop.
 
 **Paste** — `claude_desktop_config.json`
 
 ```json
 {
   "mcpServers": {
-    "faf": { "command": "npx", "args": ["-y", "claude-faf-mcp"] }
+    "faf": { "command": "bunx", "args": ["claude-faf-mcp"] }
   }
 }
 ```


### PR DESCRIPTION
## Why

Cohort-wide sweep — verified live this session that all three FAF MCP Vercel endpoints (`grok-faf-mcp` / `claude-faf-mcp` / `faf-mcp`) return HTTP 000 at root + `/sse` (function hangs without sending headers). Vercel platform itself is healthy: `faf-voice.vercel.app` responds 200 in 157ms, status page = All Systems Operational.

Isolated cause: the v1.4.x single-source-scoring-from-`faf-cli` import is likely exceeding cold-start budget in the FAF MCP `api/index.ts` catch-all pattern.

## What

A-track (this PR — public correctness restored now):

- **Remove 'Web — best of all scenarios' subsection** from Quick Start (was publishing `claude mcp add --transport http claude-faf-mcp https://claude-faf-mcp.vercel.app/sse` — the install command pointed at a hanging endpoint)
- **Swap `command: "npx"` → `command: "bunx"`** in both the paste-prompt JSON and the manual config JSON (drop `-y` flag, not needed for bunx)

bunx verified working locally against this package (still running at 3s, MCP server holds stdio open as expected). Empirical perf delta from the cohort bench: bunx warm-start ~2s vs npx ~10s (5× wall-clock, 26× CPU).

## Restore when hosted is back

When the B-track root cause is fixed and `https://claude-faf-mcp.vercel.app/sse` is verifiably stable again, restore the 'Web — best of all scenarios' subsection. Diff in this PR is minimal — easy to revert that single section.

## Cohort

- `grok-faf-mcp`: shipped via commit `5c5c7d1` direct to main (matches that repo's established direct-docs pattern)
- `claude-faf-mcp`: **this PR**
- `faf-mcp`: TBD — pending decision on PR vs direct for that repo

Doctrine receipts: [[silent-drift-equals-fail-equals-forbidden]] applied at the README-leads-with-broken-default layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)