### PR TITLE
chore: soft-deprecate faf_chat (redundant chat-shim)

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -331,21 +331,9 @@ export class FafToolHandler {
             additionalProperties: false
           }
         },
-        {
-          name: 'faf_chat',
-          description: '🗣️ Natural language project.faf generation - Ask 6W questions (Who/What/Why/Where/When/How) to build complete human context 🧡⚡️',
-          annotations: {
-            title: 'Chat about FAF',
-            readOnlyHint: true,
-            destructiveHint: false,
-            openWorldHint: false
-          },
-          inputSchema: {
-            type: 'object',
-            properties: {},
-            additionalProperties: false
-          }
-        },
+        // faf_chat — DEPRECATED, un-advertised. The host IS the chat (Claude Desktop /
+        // Claude Code); a chat-shim tool is redundant. Dispatch keeps a deprecation
+        // stub (below). Fleet sweep — mirrors grok-faf-mcp's retire.
         {
           name: 'faf_friday',
           description: '🎉 Friday Features - Chrome Extension detection, fuzzy matching & more! 🧡⚡️',
@@ -1404,39 +1392,19 @@ ${debugInfo.permissions.fafError ? `   FAF Error: ${debugInfo.permissions.fafErr
   }
 
   private async handleFafChat(_args: any): Promise<CallToolResult> {
-    try {
-      const result = await this.engineAdapter.callEngine('chat');
-
-      if (!result.success) {
-        return {
-          content: [{
-            type: 'text',
-            text: `Error running faf chat: ${result.error || 'Unknown error'}`
-          }],
-          isError: true
-        };
-      }
-
-      // Format the response text
-      const responseText = typeof result.data === 'string'
-        ? result.data
-        : result.data?.output || JSON.stringify(result.data, null, 2);
-
-      return {
-        content: [{
-          type: 'text',
-          text: responseText
-        }]
-      };
-    } catch (error) {
-      return {
-        content: [{
-          type: 'text',
-          text: `Error running faf chat: ${error instanceof Error ? error.message : String(error)}`
-        }],
-        isError: true
-      };
-    }
+    // DEPRECATED: the host (Claude Desktop / Claude Code) IS the chat — a chat-shim
+    // MCP tool is redundant. Un-advertised in listTools; this stub stays so anyone
+    // still wired gets a clear signal, not a crash. The old body shelled `faf chat`
+    // via the engine subprocess (a command faf-cli no longer ships) — removing it
+    // ends that dead shell too.
+    return {
+      content: [{
+        type: 'text',
+        text:
+          'faf_chat is retired — the host is your chat, just talk here. ' +
+          'For FAF: faf_init / faf_score / faf_sync, or "ask questions" to build context.',
+      }],
+    };
   }
 
   private async handleFafFriday(args: any): Promise<CallToolResult> {


### PR DESCRIPTION
## What
Soft-deprecate **`faf_chat`**: un-advertised from listTools; the handler is kept as a deprecation stub (still callable → a clear notice, not "unknown tool").

## Why
The host IS the chat (Claude Desktop / Claude Code) — a chat-shim MCP tool is redundant. The old body shelled `faf chat` via the engine subprocess, a command faf-cli no longer ships.

## Receipts
- build clean (tsc)
- **47 pass / 0 fail** (`visibility` + `wjttc-bun`)
- Fleet sweep — mirrors `grok-faf-mcp` + `faf-mcp`. (`championship-tools.ts` also defines `faf_chat` but isn't the wired handler here; left for the full removal pass.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
