### PR TITLE
fix(mcp): stdio capability completeness (v5.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- faf: claude-faf-mcp | TypeScript | mcp-server | FAF MCP server for Claude Desktop — persistent project context, 32 tools -->
-<!-- faf: doc=changelog | latest=v5.6.0 | canonical=project.faf | family=FAF -->
+<!-- faf: doc=changelog | latest=v5.6.2 | canonical=project.faf | family=FAF -->
 
 # Changelog
 
@@ -8,6 +8,22 @@ All notable changes to claude-faf-mcp will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [5.6.2] - 2026-06-08
+
+MCP capability completeness — the stdio server now answers every capability it
+advertises. Strict clients (Claude Desktop, Cursor) and Glama's Inspector probe
+each advertised capability; a `-32601` flags the server even when tools work.
+
+### Fixed
+
+- **`resources/templates/list` now returns `{ resourceTemplates: [] }`** instead
+  of `-32601`. Registered `ListResourceTemplatesRequestSchema` (`src/server.ts`).
+- **Dropped unbacked `subscribe: true`** from the advertised `resources`
+  capability (no subscribe handler exists) → `resources: { listChanged: true }`.
+  `/info` payload aligned. `prompts` was already backed — unchanged.
+
+No tool changes. Repo hygiene (prior): removed 41MB of committed build artifacts.
 
 ## [5.6.1] - 2026-05-26
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-faf-mcp",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "mcpName": "io.github.Wolfe-Jam/claude-faf-mcp",
   "description": "Persistent Project Context for Claude. IANA-registered .faf format, 33 MCP tools, 391 tests.",
   "icon": "./assets/icons/faf-icon-256.png",

--- a/server.json
+++ b/server.json
@@ -32,7 +32,7 @@
       ]
     }
   ],
-  "version": "5.6.1",
+  "version": "5.6.2",
   "repository": {
     "url": "https://github.com/Wolfe-Jam/claude-faf-mcp",
     "source": "github"
@@ -48,7 +48,7 @@
     {
       "registryType": "npm",
       "identifier": "claude-faf-mcp",
-      "version": "5.6.1",
+      "version": "5.6.2",
       "transport": {
         "type": "stdio"
       }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-import { CallToolRequestSchema, ListResourcesRequestSchema, ListToolsRequestSchema, ReadResourceRequestSchema, ListPromptsRequestSchema, GetPromptRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolRequestSchema, ListResourcesRequestSchema, ListResourceTemplatesRequestSchema, ListToolsRequestSchema, ReadResourceRequestSchema, ListPromptsRequestSchema, GetPromptRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { FafResourceHandler } from './handlers/resources';
 import { FafToolHandler } from './handlers/tools';
 import { FafPromptHandler } from './handlers/prompts';
@@ -43,8 +43,10 @@ export class ClaudeFafMcpServer {
       },
       {
         capabilities: {
+          // No subscribe/unsubscribe handler is registered, so do NOT advertise
+          // `subscribe` — advertising it makes resources/subscribe -32601, which
+          // trips strict clients / Glama's capability health-check.
           resources: {
-            subscribe: true,
             listChanged: true,
           },
           tools: {
@@ -80,6 +82,13 @@ export class ClaudeFafMcpServer {
 
     this.server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       return this.resourceHandler.readResource(request.params.uri);
+    });
+
+    // Resource templates: none defined. The advertised `resources` capability
+    // must answer this method with a valid (empty) list rather than -32601 —
+    // strict clients and Glama's MCP Inspector probe every advertised capability.
+    this.server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+      return { resourceTemplates: [] };
     });
 
     // Prompt handlers
@@ -154,7 +163,7 @@ export class ClaudeFafMcpServer {
         description: 'Universal FAF MCP Server for Claude - AI Context Intelligence & Project Enhancement',
         transport: 'http-sse',
         capabilities: {
-          resources: { subscribe: true, listChanged: true },
+          resources: { listChanged: true },
           tools: { listChanged: true }
         },
         tools: [


### PR DESCRIPTION
Advertised `resources {subscribe:true}` with **no `resources/templates/list` handler and no subscribe handler** → `-32601` on both. Strict clients (Claude Desktop, Cursor) + Glama's Inspector probe every advertised capability and flag the server even when tools work.

**Fix (`src/server.ts`):** register `ListResourceTemplatesRequestSchema` → `{ resourceTemplates: [] }`; drop unbacked `subscribe:true` → `resources: { listChanged: true }` (/info aligned). `prompts` already backed.

**Verified on the stdio binary:** `caps.resources={listChanged:true}`, `resources/templates/list→{resourceTemplates:[]}`. 422 pass / 0 fail. → **v5.6.2**.

---
Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)