### PR TITLE
fix(docs): correct tool count + version + dead PR link

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <title>claude-faf-mcp | Persistent Project Context for Claude</title>
-  <meta name="description" content="Claude Desktop MCP — 38 tools. Persistent .faf project context. IANA-registered format (application/vnd.faf+yaml). Anthropic MCP Registry #2759.">
+  <meta name="description" content="Claude Desktop MCP — 32 tools. Persistent .faf project context. IANA-registered format (application/vnd.faf+yaml). Anthropic MCP Registry #2759.">
   <meta property="og:title" content="claude-faf-mcp | Persistent Project Context for Claude">
-  <meta property="og:description" content="Claude Desktop MCP — 38 tools, zero config, persistent AI context. IANA-registered .faf format.">
+  <meta property="og:description" content="Claude Desktop MCP — 32 tools, zero config, persistent AI context. IANA-registered .faf format.">
   <meta property="og:image" content="https://raw.githubusercontent.com/Wolfe-Jam/claude-faf-mcp/main/assets/thumbnail.png">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🍊</text></svg>">
   <style>
@@ -240,16 +240,16 @@
   </style>
 </head>
 <body>
-  <a class="version-badge" href="https://github.com/Wolfe-Jam/claude-faf-mcp" target="_blank" rel="noopener" style="position:fixed;top:14px;left:14px;z-index:9999;text-decoration:none;" title="claude-faf-mcp on GitHub">v5.6.1</a>
+  <a class="version-badge" href="https://github.com/Wolfe-Jam/claude-faf-mcp" target="_blank" rel="noopener" style="position:fixed;top:14px;left:14px;z-index:9999;text-decoration:none;" title="claude-faf-mcp on GitHub">v5.6.2</a>
   <div class="accent-line"></div>
   <div class="container">
     <div class="logo">🍊</div>
     <h1>claude-faf-mcp</h1>
     <div class="tagline">🤖 Claude Desktop MCP <span class="version-badge" onclick="showAbout()">v5.5.2</span></div>
-    <div class="registry-line">Official <a href="https://github.com/modelcontextprotocol/registry/pull/2759">Anthropic MCP Registry</a> · IANA-registered <code>application/vnd.faf+yaml</code></div>
+    <div class="registry-line">Official <a href="https://github.com/modelcontextprotocol/servers/pull/2759">Anthropic MCP Registry</a> · IANA-registered <code>application/vnd.faf+yaml</code></div>
 
     <div class="stats">
-      <div><div class="stat-value">38</div><div class="stat-label">MCP Tools</div></div>
+      <div><div class="stat-value">32</div><div class="stat-label">MCP Tools</div></div>
       <div><div class="stat-value">0</div><div class="stat-label">Config Required</div></div>
       <div><div class="stat-value">100%</div><div class="stat-label">Trophy Scored</div></div>
     </div>
@@ -309,10 +309,10 @@
     <div class="about-box">
       <div class="about-version">v5.5.2</div>
       <div class="about-title">Persistent Project Context</div>
-      <div class="about-subtitle">Mk4 Championship Scoring · 38 Tools</div>
+      <div class="about-subtitle">Mk4 Championship Scoring · 32 Tools</div>
       <div class="about-items">
         <div class="about-item"><span>Engine:</span> Mk4 WASM via faf-scoring-kernel</div>
-        <div class="about-item"><span>Tools:</span> 38 MCP tools for Claude Desktop</div>
+        <div class="about-item"><span>Tools:</span> 32 MCP tools for Claude Desktop</div>
         <div class="about-item"><span>Scoring:</span> 0-100% Trophy, type-aware slots</div>
         <div class="about-item"><span>Fallback:</span> Mk3.1 TypeScript (zero downtime)</div>
         <div class="about-item"><span>Format:</span> IANA-registered .faf (application/vnd.faf+yaml)</div>
@@ -323,7 +323,7 @@
     </div>
   </div>
 
-  <a href="https://twitter.com/intent/tweet?text=claude-faf-mcp%20%E2%80%94%20persistent%20project%20context%20for%20Claude%20Desktop.%2038%20tools.%20IANA-registered%20.faf%20format.&url=https%3A%2F%2Fnpmjs.com%2Fpackage%2Fclaude-faf-mcp" target="_blank" rel="noopener"
+  <a href="https://twitter.com/intent/tweet?text=claude-faf-mcp%20%E2%80%94%20persistent%20project%20context%20for%20Claude%20Desktop.%2032%20tools.%20IANA-registered%20.faf%20format.&url=https%3A%2F%2Fnpmjs.com%2Fpackage%2Fclaude-faf-mcp" target="_blank" rel="noopener"
      style="position:fixed;bottom:20px;right:20px;z-index:9999;display:flex;align-items:center;gap:6px;background:#1a1a1a;color:#fff;border:1px solid #333;border-radius:20px;padding:8px 14px;font-size:0.8rem;font-weight:600;text-decoration:none;transition:all 0.2s;font-family:-apple-system,BlinkMacSystemFont,sans-serif;box-shadow:0 2px 8px rgba(0,0,0,0.3);"
      onmouseover="this.style.background='#ff6600';this.style.borderColor='#ff6600';"
      onmouseout="this.style.background='#1a1a1a';this.style.borderColor='#333';">


### PR DESCRIPTION
Fixes stale/broken content on the static docs page (`docs/index.html`):

- **Dead MCP Registry PR link** — `modelcontextprotocol/registry/pull/2759` (404) → `modelcontextprotocol/servers/pull/2759` (verified 200).
- **Tool count** — `38 tools` → `32 tools` everywhere (`faf_chat` was retired). Updated: meta description, og:description, stats card stat-value, About subtitle, About tools line, and the X share intent text.
- **Version badge** — `v5.6.1` → `v5.6.2` (current live npm version; 5.7.0 not yet published).

Verified before commit: the servers PR URL returns 200, `grep -nE '38 tools|registry/pull/2759|v5\.6\.1' docs/index.html` returns nothing, HTML tags balanced.

---
Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)