### PR TITLE
fix(docs): version-placement doctrine — top-left, single, dynamic + Edition-Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <!-- faf: claude-faf-mcp | TypeScript | mcp-server | FAF MCP server for Claude — persistent project context, 32 tools -->
 <!-- faf: doc=readme | canonical=project.faf | score=100 | family=FAF -->
 
-# claude-faf-mcp v5.7 — The Canonical Edition
+# claude-faf-mcp — The Canonical Edition
 
+[![npm version](https://img.shields.io/npm/v/claude-faf-mcp?color=00CCFF)](https://www.npmjs.com/package/claude-faf-mcp)
 [![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)](https://faf.one)
 [![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-008B8B)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-008B8B)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
 [![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
@@ -15,7 +16,6 @@
 [![FAF](https://mcpaas.live/badge/Wolfe-Jam/claude-faf-mcp.svg)](https://builder.faf.one)
 [![Anthropic MCP](https://img.shields.io/badge/Anthropic_MCP-merged_%232759-blueviolet)](https://github.com/modelcontextprotocol/servers/pull/2759)
 [![CI](https://github.com/Wolfe-Jam/claude-faf-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/Wolfe-Jam/claude-faf-mcp/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/claude-faf-mcp?color=00CCFF)](https://www.npmjs.com/package/claude-faf-mcp)
 [![NPM Downloads](https://img.shields.io/npm/dt/claude-faf-mcp?label=downloads&color=00CCFF)](https://www.npmjs.com/package/claude-faf-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Chat to FAFA live](https://img.shields.io/badge/Chat_to_FAFA_live-008B8B?style=flat&labelColor=000)](https://faf-voice.vercel.app/agent)

--- a/docs/index.html
+++ b/docs/index.html
@@ -240,12 +240,12 @@
   </style>
 </head>
 <body>
-  <a class="version-badge" href="https://github.com/Wolfe-Jam/claude-faf-mcp" target="_blank" rel="noopener" style="position:fixed;top:14px;left:14px;z-index:9999;text-decoration:none;" title="claude-faf-mcp on GitHub">v5.6.2</a>
+  <a id="versionBadge" class="version-badge" href="https://github.com/Wolfe-Jam/claude-faf-mcp" target="_blank" rel="noopener" style="position:fixed;top:14px;left:14px;z-index:9999;text-decoration:none;" title="claude-faf-mcp on GitHub">v5.6.2</a>
   <div class="accent-line"></div>
   <div class="container">
     <div class="logo">🍊</div>
     <h1>claude-faf-mcp</h1>
-    <div class="tagline">🤖 Claude Desktop MCP <span class="version-badge" onclick="showAbout()">v5.5.2</span></div>
+    <div class="tagline">🤖 <span class="version-badge" onclick="showAbout()">The Canonical Edition</span></div>
     <div class="registry-line">Official <a href="https://github.com/modelcontextprotocol/servers/pull/2759">Anthropic MCP Registry</a> · IANA-registered <code>application/vnd.faf+yaml</code></div>
 
     <div class="stats">
@@ -299,7 +299,7 @@
     </div>
 
     <div class="bottom-bar">
-      <div class="links"><span class="version-badge" onclick="showAbout()" style="font-size:0.75rem;padding:3px 10px;">v5.5.2</span> &bull; <a href="https://github.com/Wolfe-Jam/claude-faf-mcp">GitHub</a> &bull; <a href="https://npmjs.com/package/claude-faf-mcp">npm</a> &bull; <a href="https://faf.one">faf.one</a> &bull; <a href="https://mcpaas.live">mcpaas.live</a></div>
+      <div class="links"><a href="https://github.com/Wolfe-Jam/claude-faf-mcp">GitHub</a> &bull; <a href="https://npmjs.com/package/claude-faf-mcp">npm</a> &bull; <a href="https://faf.one">faf.one</a> &bull; <a href="https://mcpaas.live">mcpaas.live</a></div>
       <div class="big-orange">Part of the FAF MCP family 🍊</div>
       <div style="margin-top:0.5rem;font-size:0.75rem;"><a href="https://mcpaas.live/privacy" style="color:#666;text-decoration:none;">Privacy</a> · <a href="https://mcpaas.live/terms" style="color:#666;text-decoration:none;">Terms</a> · <a href="mailto:team@faf.one" style="color:#666;text-decoration:none;">team@faf.one</a></div>
       <div style="margin-top:0.75rem;padding-top:0.75rem;border-top:1px solid rgba(255,255,255,0.1);font-size:0.8rem;color:#fff;">Part of the <a href="https://faf.one" style="color:#ff6600;text-decoration:none;">FAF.one Family</a> · <a href="https://mcpaas.live" style="color:#888;text-decoration:none;">MCPaaS</a> · <a href="https://radiofaf.com" style="color:#888;text-decoration:none;">RadioFAF</a> · <a href="https://fafdev.tools" style="color:#888;text-decoration:none;">fafdev.tools</a></div>
@@ -307,7 +307,7 @@
   </div>
   <div class="about-overlay" id="aboutOverlay" onclick="if(event.target===this)hideAbout()">
     <div class="about-box">
-      <div class="about-version">v5.5.2</div>
+      <div class="about-version">The Canonical Edition</div>
       <div class="about-title">Persistent Project Context</div>
       <div class="about-subtitle">Mk4 Championship Scoring · 32 Tools</div>
       <div class="about-items">
@@ -361,6 +361,13 @@
       document.getElementById('aboutOverlay').classList.remove('visible');
     }
     window.addEventListener('load', function() { setTimeout(function() { showAbout(true); }, 500); });
+
+    // Single source of truth for the version: read npm live so the badge can never drift.
+    // The hardcoded text above is just a fallback if the fetch fails (offline / npm down).
+    fetch('https://registry.npmjs.org/claude-faf-mcp/latest')
+      .then(function(r) { return r.json(); })
+      .then(function(d) { if (d && d.version) document.getElementById('versionBadge').textContent = 'v' + d.version; })
+      .catch(function() { /* keep the fallback text */ });
   </script>
 </body>
 </html>


### PR DESCRIPTION
Establishes the **version-placement doctrine** (claude-faf-mcp as the template):

> The version lives in exactly **one display spot per surface, always top-left, read live** so it can't drift. Everything else uses the **Edition-Name**.

**Web (`docs/index.html`):**
- Top-left badge now **fetches `registry.npmjs.org/claude-faf-mcp/latest`** at load (hardcoded `v5.6.2` kept only as offline fallback) → self-healing
- Tagline + About box → **"The Canonical Edition"** (were `v5.5.2`/`v5.6.2`)
- Footer version removed

**README:**
- h1 drops hardcoded `v5.7` → `# claude-faf-mcp — The Canonical Edition`
- The dynamic shields.io npm-version badge **moved to first/top-left** position

Net: humans only type the version in `package.json`; both display badges derive from npm live. Same top-left position on web + README so people know where to look.

---
Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)