### PR TITLE
chore(tsconfig): drop stale api/ include

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*", "api/**/*"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
The `api/` dir (orphaned SSE-on-Vercel server) was deleted in the SSE retirement; `tsconfig.json` `include` still listed `api/**/*`. Removed it — harmless (tsc ignores missing globs) but now accurate.

Build clean · tests green · no `dist/api` output.

---
Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)