### PR TITLE
ci: auto-publish server.json to MCP Registry on release (OIDC)

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,54 @@
+name: Publish to MCP Registry
+
+# Keeps the MCP Registry (and downstream directories like Glama) in lock-step
+# with the repo: every published GitHub Release pushes the current server.json
+# to registry.modelcontextprotocol.io. No human, no hand-cranked mcp-publisher,
+# no drift (this is why claude sat at a stale v2.6.1 while the repo was at 5.7.x).
+#
+# Auth = GitHub OIDC. NO stored secret — the registry trusts the workflow's
+# identity to authorise the io.github.Wolfe-Jam/* namespace (repo owner matches).
+
+on:
+  release:
+    types: [published]      # each release = a new server.json version → publish it
+  workflow_dispatch: {}      # manual re-publish if ever needed
+
+permissions:
+  contents: read
+  id-token: write            # REQUIRED for `mcp-publisher login github-oidc`
+
+concurrency:
+  group: mcp-registry-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mcp-publisher
+        run: |
+          set -euo pipefail
+          TAG=$(curl -fsSL https://api.github.com/repos/modelcontextprotocol/registry/releases/latest \
+                  | grep -o '"tag_name"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | cut -d'"' -f4)
+          VER=${TAG#v}
+          echo "mcp-publisher ${TAG}"
+          # If this asset name ever 404s, check the registry release page for the exact name.
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/${TAG}/mcp-publisher_${VER}_linux_amd64.tar.gz" \
+            | tar -xz mcp-publisher
+          chmod +x mcp-publisher
+
+      - name: Validate server.json
+        run: ./mcp-publisher validate
+
+      - name: Authenticate (GitHub OIDC — no stored secret)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish to MCP Registry
+        run: ./mcp-publisher publish
+
+      - name: Confirm
+        run: |
+          echo "Published $(grep -o '\"version\"[^,]*' server.json | head -1) to the MCP Registry."
+          echo "Glama and other directories will re-sync from the registry on their next crawl."


### PR DESCRIPTION
**The structural fix** for the registry drift that started this whole Glama saga (claude was stuck at registry v2.6.1/no-remotes while the repo was at 5.7.x — because publishing was manual and got skipped for ~30 releases).

- Fires on every **published Release** (+ `workflow_dispatch`)
- Auth = **GitHub OIDC** — *no stored secret*; the registry authorises `io.github.Wolfe-Jam/*` from the workflow's identity (repo owner matches)
- Steps: install `mcp-publisher` → `validate` → `login github-oidc` → `publish`

After this, the registry can't drift from the repo, and Glama re-syncs from an always-current registry. Template-able across the cohort.

⚠️ One line to sanity-check on first run: the `mcp-publisher` binary download asset name (commented in the workflow) — if the registry's release assets are named differently it'll 404, easy fix.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*