### PR TITLE
ci(polish): idempotent MCP-registry publish (green on re-run)

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -41,13 +41,27 @@ jobs:
       - name: Validate server.json
         run: ./mcp-publisher validate
 
+      - name: Check if this version is already published (idempotent)
+        id: ver
+        run: |
+          NAME=$(jq -r .name server.json)
+          LOCAL=$(jq -r .version server.json)
+          PUBLISHED=$(curl -fsSL "https://registry.modelcontextprotocol.io/v0/servers?search=${NAME}&version=latest" \
+            | jq -r --arg n "$NAME" '[.servers[].server | select(.name==$n) | .version] | first // ""')
+          if [ "$LOCAL" = "$PUBLISHED" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "✓ ${NAME} v${LOCAL} is already the registry's latest — nothing to do."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+            echo "${NAME} v${LOCAL} not yet published (registry latest: ${PUBLISHED:-none}) — will publish."
+          fi
+
       - name: Authenticate (GitHub OIDC — no stored secret)
+        if: steps.ver.outputs.publish == 'true'
         run: ./mcp-publisher login github-oidc
 
       - name: Publish to MCP Registry
-        run: ./mcp-publisher publish
-
-      - name: Confirm
+        if: steps.ver.outputs.publish == 'true'
         run: |
-          echo "Published $(grep -o '\"version\"[^,]*' server.json | head -1) to the MCP Registry."
-          echo "Glama and other directories will re-sync from the registry on their next crawl."
+          ./mcp-publisher publish
+          echo "Published $(jq -r .version server.json) to the MCP Registry. Glama re-syncs on its next crawl."


### PR DESCRIPTION
Skips publish when server.json version == registry's latest → manual dispatch is green instead of red-on-duplicate. Real releases still publish.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*