### PR TITLE
fix(engine-adapter): cwd path-check — stop forcing ~/Projects over the open workspace

### DIFF
--- a/src/handlers/engine-adapter.ts
+++ b/src/handlers/engine-adapter.ts
@@ -109,7 +109,28 @@ export class FafEngineAdapter {
       return mcpWorkingDir;
     }
 
-    // Priority 3: FORCE ~/Projects as universal default
+    // Priority 3 (FIX 2026-06-30): the caller's ACTUAL working directory — the
+    // workspace an IDE / MCP host (Claude Desktop, Cursor, VS Code) launches the
+    // server in. This MUST win over the ~/Projects convention below. Previously
+    // ~/Projects was FORCED here, so every no-path tool call that resolves via
+    // the engine adapter operated on ~/Projects instead of the project the user
+    // actually had open. Prefer a real FAF project (cwd contains project.faf —
+    // the path-check), else the cwd itself when it's a usable, non-root
+    // directory (so faf_init/score act on the open workspace even before a .faf
+    // exists). Shared fix across faf-mcp / grok-faf-mcp / claude-faf-mcp.
+    const currentDir = process.cwd();
+    const usableCwd =
+      currentDir !== '/' && currentDir !== '/root' && fs.existsSync(currentDir);
+    if (usableCwd && fs.existsSync(path.join(currentDir, 'project.faf'))) {
+      return currentDir;
+    }
+    if (usableCwd) {
+      return currentDir;
+    }
+
+    // Priority 4: ~/Projects convention — a soft landing ONLY when the host gave
+    // us no usable workspace (e.g. cwd is the filesystem root). Never overrides a
+    // real cwd above.
     const homeDir = process.env.HOME ?? process.env.USERPROFILE;
     if (homeDir) {
       // Try capitalized Projects first (macOS/Windows convention)
@@ -132,12 +153,6 @@ export class FafEngineAdapter {
         // Fall back to home
         return homeDir;
       }
-    }
-
-    // Priority 4: Current directory if not root
-    const currentDir = process.cwd();
-    if (currentDir !== '/' && currentDir !== '/root' && fs.existsSync(currentDir)) {
-      return currentDir;
     }
 
     // Last resort: /tmp (should rarely happen)

--- a/tests/wjttc-cwd-resolution.test.ts
+++ b/tests/wjttc-cwd-resolution.test.ts
@@ -1,0 +1,62 @@
+/**
+ * 🏁 WJTTC — working-directory resolution (the cwd path-check)
+ *
+ * Regression for the "FORCE ~/Projects as universal default" bug (shared across
+ * faf-mcp / grok-faf-mcp / claude-faf-mcp): the engine adapter resolved the
+ * working directory to ~/Projects ABOVE the caller's cwd, so every no-path tool
+ * call (faf_score, …) operated on ~/Projects instead of the project the user
+ * had open. claude-faf-mcp is actively affected (getProjectPath → getWorkingDirectory).
+ *
+ * The fix: the caller's actual cwd wins. Prefer a real FAF project (cwd has a
+ * project.faf — the path-check), else the cwd itself when usable + non-root;
+ * ~/Projects is a fallback ONLY when there's no usable workspace (cwd is root) —
+ * which preserves the Claude-Desktop-launched-at-root landing.
+ */
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { FafEngineAdapter } from '../src/handlers/engine-adapter';
+
+let tmp: string;
+let origCwd: string;
+
+beforeEach(() => {
+  origCwd = process.cwd();
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cwd-resolve-'));
+});
+afterEach(() => {
+  process.chdir(origCwd);
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+});
+
+describe('AERO — cwd path-check wins over the ~/Projects convention', () => {
+  test('cwd containing a project.faf is the working directory (not ~/Projects)', () => {
+    fs.writeFileSync(path.join(tmp, 'project.faf'), 'faf_version: "3.0"\nproject:\n  name: t\n');
+    process.chdir(tmp);
+    const adapter = new FafEngineAdapter();
+    // fs.realpath to dodge /var↔/private symlink noise on macOS tmp.
+    expect(fs.realpathSync(adapter.getWorkingDirectory())).toBe(fs.realpathSync(tmp));
+  });
+
+  test('a usable non-root cwd WITHOUT a .faf is still preferred over ~/Projects', () => {
+    process.chdir(tmp);
+    const adapter = new FafEngineAdapter();
+    expect(fs.realpathSync(adapter.getWorkingDirectory())).toBe(fs.realpathSync(tmp));
+  });
+
+  test('explicit FAF_WORKING_DIR still overrides everything (priority 1 intact)', () => {
+    const override = fs.mkdtempSync(path.join(os.tmpdir(), 'cwd-override-'));
+    process.chdir(tmp);
+    const prev = process.env.FAF_WORKING_DIR;
+    process.env.FAF_WORKING_DIR = override;
+    try {
+      const adapter = new FafEngineAdapter();
+      expect(fs.realpathSync(adapter.getWorkingDirectory())).toBe(fs.realpathSync(override));
+    } finally {
+      if (prev === undefined) delete process.env.FAF_WORKING_DIR;
+      else process.env.FAF_WORKING_DIR = prev;
+      fs.rmSync(override, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Shared-lineage fix — the same `findBestWorkingDirectory()` "FORCE `~/Projects` as universal default" bug found in **faf-mcp** ([#67](https://github.com/Wolfe-Jam/faf-mcp/pull/67)) and **grok-faf-mcp** ([#139](https://github.com/Wolfe-Jam/grok-faf-mcp/pull/139)) ships byte-identical here.

**Impact here: ACTIVE (like faf-mcp).** `getProjectPath()` defaults to `engineAdapter.getWorkingDirectory()`, so a no-path `faf_score` from **Claude Code in a real project** resolved to `~/Projects` and scored its stale `.faf` — not the project the user had open.

**Fix:** the caller's actual cwd wins — prefer a real FAF project (`cwd` has `project.faf` — the path-check), else a usable non-root `cwd`; `~/Projects` becomes a fallback **only** when `cwd` is the filesystem root. That **preserves the Claude-Desktop-launched-at-root landing** (Desktop launches globally → cwd is root → still lands on `~/Projects`) while fixing Claude Code (which runs inside the project).

**Verification:** typecheck clean · new `tests/wjttc-cwd-resolution.test.ts` (3/3) pinning cwd-with-`.faf` and usable-non-root-cwd winning over `~/Projects`, with `FAF_WORKING_DIR` override intact.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*