### PR TITLE
fix: refresh agent.fafa to 5.20.0 + add .fafa verifier

### DIFF
--- a/agent.fafa
+++ b/agent.fafa
@@ -7,9 +7,8 @@ agent:
   name: claude-faf-mcp
   id: did:web:faf.one:claude-faf-mcp
   vendor: WolfeJAM
-  version: 5.8.0
-  description: Persistent project context for Claude — define once, never
-    re-explain. The FAF Context MCP for Claude Desktop and Claude Code.
+  version: 5.20.0
+  description: Persistent project context for Claude — define once, never re-explain. The FAF Context MCP for Claude Desktop and Claude Code.
   homepage: https://faf.one
   license: MIT
 capabilities:
@@ -21,7 +20,7 @@ capabilities:
       - faf
   - name: faf_about
     type: tool
-    description: Learn what .faf format is - project DNA for AI
+    description: Explain what the FAF format is — project DNA for AI — with its IANA registration, version, and connected platforms. Returns format metadata and the available MCP bridges. Use this when someone asks what FAF is or how it connects to other AI tools.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
@@ -33,19 +32,19 @@ capabilities:
       - faf
   - name: faf_score
     type: tool
-    description: Calculate your project's AI-readability from project.faf (project DNA for AI) - F1-inspired metrics!
+    description: Score a project.faf and return its 0–100% AI-readability, tier, and per-slot breakdown, via the deterministic Mk4 engine. Use this for a quick status check; use faf_doctor when you need to diagnose and fix what's missing.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
   - name: faf_init
     type: tool
-    description: "Create project.faf (project DNA for AI) - Makes your project instantly AI-readable . Just enter path or project name. Examples: ~/Projects/my-app, my-app, /full/path/to/project"
+    description: Create a new project.faf with a name, goal, and language. Returns the file path and starting score. Won't overwrite an existing file — use faf_auto to fill the stack from your manifests, or faf_go for the human 6Ws.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
   - name: faf_trust
     type: tool
-    description: Attest project.faf integrity — validity, score, and a deterministic parity hash any conformant engine reproduces.
+    description: "Attest a project.faf's integrity: its validity, score, and a deterministic parity hash any conformant engine reproduces. Returns the ✪ receipt. Use this to prove a score is genuine and untampered."
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
@@ -57,19 +56,13 @@ capabilities:
       - faf
   - name: faf_sync
     type: tool
-    description: Sync project.faf (project DNA for AI) with CLAUDE.md - Bi-directional context
+    description: Sync project.faf into CLAUDE.md as a faf-managed block, and optionally into AGENTS.md (agents), .cursorrules (cursor), GEMINI.md (gemini), and .github/copilot-instructions.md (copilot) — or all of them (all). Updates each block in place — it never overwrites your file. Use this after editing project.faf so every AI tool sees the latest context.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
   - name: faf_enhance
     type: tool
-    description: Enhance project.faf (project DNA for AI) with AI optimization — persistent context, zero drift
-    cites_spec: application/vnd.faf+yaml
-    tags:
-      - faf
-  - name: faf_bi_sync
-    type: tool
-    description: "Bi-directional sync between project.faf and CLAUDE.md. v4.5.0: Also sync to AGENTS.md, .cursorrules, GEMINI.md!"
+    description: Refine a project.faf with an AI model (claude/gemini/grok, optionally by consensus). Returns the enhanced content, or a dry-run preview when dryRun is set. Use this to polish after faf_auto and faf_go have filled the slots.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
@@ -135,19 +128,25 @@ capabilities:
       - faf
   - name: faf_context
     type: tool
-    description: Set or view active project context - Path is remembered for subsequent faf_ calls
+    description: Set or show the active project path that subsequent faf_ calls resolve against. Returns the current context path. Call this once at the start of a session so the other tools target the right project.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
   - name: faf_go
     type: tool
-    description: "Guided interview to Gold Code (100%): returns questions for missing fields, then applies your answers."
+    description: The friendly front door — "let's go, tell me about your idea." Asks the human the 6Ws (goal, why, who, what, where, when) that can't be auto-detected, then applies them to project.faf. If no project.faf exists yet, faf_go bootstraps it first (creates it, sources the stack) so you go from nothing to the 6Ws in one step. Returns the Table-of-8 to confirm/answer, or applies the answers you pass back. Use faf_auto for the technical stack on its own.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
   - name: faf_auto
     type: tool
-    description: "Run the full FAF pipeline in one step: init + sync + formats + bi-sync + score."
+    description: Scan your manifests (package.json, Cargo.toml, pyproject.toml, go.mod…) and fill the project.faf stack slots from real dependencies — no hardcoded defaults. Returns what was detected and the updated score. Use this for the technical context; use faf_go for the human 6Ws it can't detect, and faf_enhance to have an AI refine the result.
+    cites_spec: application/vnd.faf+yaml
+    tags:
+      - faf
+  - name: faf_bench
+    type: tool
+    description: Prove the .faf earns its place — measure how much the context is worth, on THIS repo, falsifiably. Questions derive from the project.faf's own populated slots (the .faf is the answer key), so grading is mechanical — no judge, no rubric. action=questions returns the answer-key-safe question set; action=grade takes your answers WITHOUT the .faf (cold) and WITH it (faf), grades both, and returns the cold→with-faf lift with a ✪ receipt. The delta is the product; the cold number belongs to the absence of context, never to FAF.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
@@ -165,13 +164,13 @@ capabilities:
       - faf
   - name: faf_quick
     type: tool
-    description: "Lightning-fast .faf creation - One-liner format: \"name, description, language, framework, hosting\""
+    description: 'Lightning-fast .faf creation - One-liner format: "name, description, language, framework, hosting"'
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
   - name: faf_doctor
     type: tool
-    description: Health check for your .faf setup - Diagnose and fix common issues
+    description: "Diagnose a project.faf: report empty or weak slots, common issues, and how to fix each. Returns a prioritized checklist. Use this when faf_score is below target and you need to know why."
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
@@ -213,40 +212,38 @@ capabilities:
       - faf
   - name: faf_etch
     type: tool
-    description: Etch a memory — remember this across sessions (a decision, gotcha, or win). Writes to the project soul (.fafm).
+    description: Remember a decision, gotcha, or win across sessions by writing it to the project soul (.fafm). Returns the stored memory's id. Use this to persist something an AI should recall later; use faf_recall to read them back.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
   - name: faf_recall
     type: tool
-    description: Recall memories from the project soul (.fafm), ranked by priority then recency.
+    description: Recall memories from the project soul (.fafm), ranked by priority then recency, filtered by query/tags/type. Returns the matching entries. Use this to surface past decisions; use faf_etch to add new ones.
     cites_spec: application/vnd.faf+yaml
     tags:
       - faf
 endpoints:
   - protocol: mcp
-    version: "2025-06-18"
+    version: 2025-06-18
     transport: stdio
     location: claude-faf-mcp
   - protocol: mcp
-    version: "2025-06-18"
+    version: 2025-06-18
     transport: http
     location: https://mcpaas.live/claude/mcp/v1
 provenance:
   faf: ./project.faf
   mediaType: application/vnd.faf+yaml
   deterministic: true
-  generated: "2026-06-10T05:17:34Z"
+  generated: 2026-07-01T04:35:37Z
 metadata:
   repository: https://github.com/Wolfe-Jam/claude-faf-mcp
   privacy: Runs locally. No telemetry, no analytics, no data leaves the machine.
   tool_tiers:
     status: planned
     model: Essentials (~17 core) + Extended specialist kit
-    note: Capabilities declared flat for now; tier-based surfacing is a planned
-      dimension (per the tool-surface curation design), not yet finalized — no
-      fabricated split.
+    note: Capabilities declared flat for now; tier-based surfacing is a planned dimension (per the tool-surface curation design), not yet finalized — no fabricated split.
   trinity:
     context: ./project.faf (live)
-    memory: soul.fafm (planned)
+    memory: soul.fafm (live)
     agent: this card

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "postinstall": "node scripts/postinstall.js",
     "debug": "node --inspect-brk=0.0.0.0:9229 -r ts-node/register src/cli.ts",
     "pack:mcpb": "npm run build && rm -rf .mcpb-staging && mkdir .mcpb-staging && cp -r dist manifest.json package.json package-lock.json assets scripts PRIVACY.md README.md LICENSE CHANGELOG.md skill .faf .mcpb-staging/ 2>/dev/null; cd .mcpb-staging && npm install --omit=dev --ignore-scripts && rm -rf node_modules/@esbuild node_modules/esbuild node_modules/rxjs node_modules/@types node_modules/lodash node_modules/ajv-formats && npx @anthropic-ai/mcpb pack . ../claude-faf-mcp-$(node -p \"require('./package.json').version\").mcpb && cd .. && rm -rf .mcpb-staging",
-    "gen:server-card": "node scripts/gen-server-card.js"
+    "gen:server-card": "node scripts/gen-server-card.js",
+    "verify:fafa": "node scripts/verify-fafa.js"
   },
   "keywords": [
     "claude",

--- a/scripts/verify-fafa.js
+++ b/scripts/verify-fafa.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * verify-fafa.js — verify a FAF Agent Card (.fafa).
+ *
+ * Five layers (strongest first):
+ *   L1 accuracy    — declared capabilities == the server's LIVE tools/list
+ *   L2 shape       — valid YAML + required fields + complete capabilities
+ *   L4 A2A conform — maps to a valid A2A AgentCard (src/fafa/a2a-card)
+ *   L5 trust       — cites_spec are real FAF media types; agent.id is a did:web
+ *
+ * Usage:  node scripts/verify-fafa.js [path/to/card.fafa]   (default: ./agent.fafa)
+ * Exit 0 = all pass, 1 = a check failed. Requires `npm run build` (uses dist/).
+ */
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const root = path.join(__dirname, '..');
+const yaml = require(path.join(root, 'node_modules/yaml'));
+const cardPath = process.argv[2] || path.join(root, 'agent.fafa');
+
+let pass = 0, fail = 0;
+const ok = (n, c, x = '') => { console.log(`  ${c ? 'PASS' : 'FAIL'}  ${n}${x ? ' — ' + x : ''}`); c ? pass++ : fail++; };
+
+console.log('verify-fafa:', cardPath, '\n');
+
+let card;
+try { card = yaml.parse(fs.readFileSync(cardPath, 'utf8')); ok('L2 valid YAML', true); }
+catch (e) { ok('L2 valid YAML', false, e.message); process.exit(1); }
+
+['version', 'agent', 'capabilities', 'endpoints', 'provenance'].forEach((k) => ok('L2 required field: ' + k, k in card));
+ok('L2 agent identity (name+id+version)', !!(card.agent && card.agent.name && card.agent.id && card.agent.version), 'v' + (card.agent && card.agent.version));
+ok('L2 every capability complete (name+description+cites_spec)', card.capabilities.every((c) => c.name && c.description && c.cites_spec), card.capabilities.length + ' caps');
+
+const specs = ['application/vnd.faf+yaml', 'application/vnd.fafm+yaml', 'application/vnd.fafa+yaml'];
+ok('L5 cites_spec are real FAF media types', card.capabilities.every((c) => specs.includes(c.cites_spec)));
+ok('L5 agent.id is a did:web', /^did:web:/.test(card.agent.id || ''), card.agent.id);
+
+// L1 accuracy — capabilities must match the live tools/list of this server
+const msgs = [
+  { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'verify-fafa', version: '1' } } },
+  { jsonrpc: '2.0', method: 'notifications/initialized' },
+  { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+].map((m) => JSON.stringify(m)).join('\n') + '\n';
+const r = spawnSync('node', [path.join(root, 'dist/src/index.js')], { input: msgs, encoding: 'utf8', env: { ...process.env, FAF_TOOLS: 'all' }, timeout: 60000, maxBuffer: 1e7 });
+let live = [];
+for (const l of (r.stdout || '').split('\n')) { const t = l.trim(); if (!t) continue; let m; try { m = JSON.parse(t); } catch { continue; } if (m.id === 2 && m.result) live = m.result.tools.map((x) => x.name); }
+const a = card.capabilities.map((c) => c.name).sort();
+const b = live.slice().sort();
+ok('L1 accuracy: capabilities == live tools/list', a.length > 0 && JSON.stringify(a) === JSON.stringify(b), `card ${a.length} / live ${b.length}`);
+
+// L4 A2A conformance — must map to a valid A2A AgentCard
+try {
+  const { fafaToA2ACard } = require(path.join(root, 'dist/src/fafa/a2a-card.js'));
+  const c = fafaToA2ACard(card, { url: 'https://faf.one/.well-known/' + path.basename(cardPath) });
+  ok('L4 A2A conformance (maps to a valid A2A AgentCard)', !!(c && c.name && Array.isArray(c.skills) && c.skills.length === card.capabilities.length), (c.skills ? c.skills.length : 0) + ' skills');
+} catch (e) { ok('L4 A2A conformance', false, e.message); }
+
+console.log(`\n${fail === 0 ? 'ALL PASS' : fail + ' FAILED'} — ${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);


### PR DESCRIPTION
The repo's canonical **`agent.fafa`** (FAF Agent Card) was stale — generated from **5.8.0** (2026-06-10). Regenerated from the **live claude-faf-mcp@5.20.0** `tools/list`: version, generated stamp, and 35 capabilities refreshed; crafted description/endpoints preserved; `trinity.memory` **planned → live** (faf_etch/faf_recall are shipped tools).

Also adds **`scripts/verify-fafa.js`** (`npm run verify:fafa`) — a reusable `.fafa` verifier (the toolchain had none):
- **L1 accuracy** — capabilities == live `tools/list`
- **L2 shape** — valid YAML + required fields + complete capabilities
- **L4 A2A** — maps to a valid A2A AgentCard
- **L5 trust** — real FAF media types + `did:web` id

Verifier passes **12/12** on the refreshed card. The served copy is synced in [faf-one-svelte-new#8](https://github.com/Wolfe-Jam/faf-one-svelte-new/pull/8).

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*