### PR TITLE
fix(fafa): A2A v1.0 AgentCard conformance (path + supportedInterfaces structure)

### DIFF
--- a/src/fafa/a2a-card.ts
+++ b/src/fafa/a2a-card.ts
@@ -9,11 +9,17 @@
  * which rides as an A2A extension (`one.faf/context`) — byte-equivalent to the MCP
  * server-card `_meta["one.faf/context"]`. One context, every door.
  *
+ * v1.0 note: the AgentCard was restructured — `url` + `protocolVersion` are folded
+ * into a REQUIRED `supportedInterfaces[]`, and extensions live under
+ * `capabilities.extensions[]` (not top-level). Source: a2aproject/A2A
+ * `specification/a2a.proto` (AgentCard / AgentInterface / AgentCapabilities).
+ *
  * Pure mapper (testable). The live A2A *invocation* endpoint (JSON-RPC `message/send`)
  * is served at the edge — this module produces the discovery card that points at it.
  */
 
 export const A2A_PROTOCOL_VERSION = '1.0';
+export const A2A_PROTOCOL_BINDING = 'JSONRPC'; // core A2A bindings: JSONRPC | GRPC | HTTP+JSON
 export const A2A_WELL_KNOWN_PATH = '/.well-known/agent-card.json';
 
 export interface A2AAgentSkill {
@@ -26,32 +32,70 @@ export interface A2AAgentSkill {
   outputModes?: string[];
 }
 
-export interface A2AAgentCard {
+/** A2A v1.0 `AgentInterface` — one endpoint + its protocol binding + protocol version. */
+export interface A2AAgentInterface {
+  url: string;
+  protocolBinding: string;
   protocolVersion: string;
+}
+
+export interface A2AAgentExtension {
+  uri: string;
+  description?: string;
+  required: boolean;
+  params?: Record<string, unknown>;
+}
+
+export interface A2AAgentCapabilities {
+  streaming: boolean;
+  pushNotifications: boolean;
+  extendedAgentCard: boolean;
+  extensions?: A2AAgentExtension[];
+}
+
+export interface A2AAgentCard {
   name: string;
   description?: string;
-  url: string;
-  version?: string;
+  supportedInterfaces: A2AAgentInterface[]; // v1.0 REQUIRED (was top-level url + protocolVersion)
   provider?: { organization?: string; url?: string };
-  capabilities: { streaming: boolean; pushNotifications: boolean; extendedAgentCard: boolean };
+  version?: string;
+  capabilities: A2AAgentCapabilities;
   defaultInputModes: string[];
   defaultOutputModes: string[];
   skills: A2AAgentSkill[];
-  extensions?: { uri: string; description?: string; required: boolean; params?: Record<string, unknown> }[];
 }
 
-/** Map a parsed `.fafa` document to a conformant A2A AgentCard. */
+/** Map a parsed `.fafa` document to a conformant A2A v1.0 AgentCard. */
 export function fafaToA2ACard(fafa: any, opts: { url: string }): A2AAgentCard {
   const agent = fafa?.agent ?? {};
-  const card: A2AAgentCard = {
-    protocolVersion: A2A_PROTOCOL_VERSION,
+  // CFM's tools are synchronous request/response; no streaming/push yet.
+  const capabilities: A2AAgentCapabilities = {
+    streaming: false,
+    pushNotifications: false,
+    extendedAgentCard: false,
+  };
+  // The enhancement: the FAF context block as an A2A extension (the durable middle).
+  // v1.0 places extensions under `capabilities.extensions[]`.
+  if (fafa?.provenance) {
+    capabilities.extensions = [{
+      uri: 'https://one.faf/context',
+      description: 'FAF context provenance — the durable context block (one context, every door).',
+      required: false,
+      params: fafa.provenance,
+    }];
+  }
+  return {
     name: agent.name,
     description: agent.description,
-    url: opts.url, // A2A service endpoint (JSON-RPC) — served at the edge
-    version: agent.version,
+    // v1.0: the A2A service endpoint (JSON-RPC) lives inside supportedInterfaces[].
+    supportedInterfaces: [{
+      url: opts.url, // a real endpoint, supplied by the caller — never baked in
+      protocolBinding: A2A_PROTOCOL_BINDING,
+      protocolVersion: A2A_PROTOCOL_VERSION,
+    }],
     provider: { organization: agent.vendor, url: agent.homepage },
-    // CFM's tools are synchronous request/response; no streaming/push yet.
-    capabilities: { streaming: false, pushNotifications: false, extendedAgentCard: false },
+    version: agent.version,
+    capabilities,
     defaultInputModes: ['text/plain', 'application/json'],
     defaultOutputModes: ['text/plain', 'application/json'],
     // A2A skill ≡ FAF capability ≡ MCP tool (per AGENT-FORMAT §3).
@@ -62,14 +106,4 @@ export function fafaToA2ACard(fafa: any, opts: { url: string }): A2AAgentCard {
       tags: Array.isArray(c.tags) ? c.tags : [],
     })),
   };
-  // The enhancement: the FAF context block as an A2A extension (the durable middle).
-  if (fafa?.provenance) {
-    card.extensions = [{
-      uri: 'https://one.faf/context',
-      description: 'FAF context provenance — the durable context block (one context, every door).',
-      required: false,
-      params: fafa.provenance,
-    }];
-  }
-  return card;
 }

--- a/src/fafa/a2a-card.ts
+++ b/src/fafa/a2a-card.ts
@@ -2,7 +2,7 @@
  * `.fafa` → A2A AgentCard mapper.
  *
  * Maps CFM's FAF Agent Card (`.fafa`) to a conformant **A2A AgentCard**
- * (A2A protocol v1.0, served at `/.well-known/a2a-agent-card`).
+ * (A2A protocol v1.0, served at `/.well-known/agent-card.json`).
  *
  * Posture: `.fafa` is a PEER to the A2A AgentCard — **compatible + enhancing**.
  * Every A2A field maps from `.fafa`; the enhancement is the **FAF context block**,
@@ -14,7 +14,7 @@
  */
 
 export const A2A_PROTOCOL_VERSION = '1.0';
-export const A2A_WELL_KNOWN_PATH = '/.well-known/a2a-agent-card';
+export const A2A_WELL_KNOWN_PATH = '/.well-known/agent-card.json';
 
 export interface A2AAgentSkill {
   id: string;

--- a/tests/fafa-a2a-card.test.ts
+++ b/tests/fafa-a2a-card.test.ts
@@ -12,12 +12,18 @@ const FAFA = {
 };
 const URL = 'https://mcpaas.live/claude/a2a';
 
-test('maps required A2A fields', () => {
+test('maps required A2A v1.0 fields (supportedInterfaces, not top-level url)', () => {
   const c = fafaToA2ACard(FAFA, { url: URL });
-  expect(c.protocolVersion).toBe(A2A_PROTOCOL_VERSION);
   expect(c.name).toBe('claude-faf-mcp');
-  expect(c.url).toBe(URL);
-  expect(c.capabilities).toEqual({ streaming: false, pushNotifications: false, extendedAgentCard: false });
+  // v1.0: no top-level url / protocolVersion — they live in supportedInterfaces[].
+  expect((c as any).url).toBeUndefined();
+  expect((c as any).protocolVersion).toBeUndefined();
+  expect(c.supportedInterfaces).toEqual([
+    { url: URL, protocolBinding: 'JSONRPC', protocolVersion: A2A_PROTOCOL_VERSION },
+  ]);
+  expect(c.capabilities.streaming).toBe(false);
+  expect(c.capabilities.pushNotifications).toBe(false);
+  expect(c.capabilities.extendedAgentCard).toBe(false);
 });
 
 test('capability → skill (id/name/description/tags), count preserved', () => {
@@ -31,17 +37,19 @@ test('provider from vendor + homepage', () => {
   expect(c.provider).toEqual({ organization: 'WolfeJAM', url: 'https://faf.one' });
 });
 
-test('FAF context block rides as a one.faf extension (NEVER io.faf)', () => {
+test('FAF context block rides as a one.faf extension under capabilities (NEVER io.faf)', () => {
   const c = fafaToA2ACard(FAFA, { url: URL });
-  expect(c.extensions).toHaveLength(1);
-  expect(c.extensions![0].uri).toBe('https://one.faf/context');
-  expect(c.extensions![0].uri).not.toContain('io.faf');
-  expect(c.extensions![0].params).toEqual(FAFA.provenance);
+  // v1.0: extensions live under capabilities, not top-level.
+  expect((c as any).extensions).toBeUndefined();
+  expect(c.capabilities.extensions).toHaveLength(1);
+  expect(c.capabilities.extensions![0].uri).toBe('https://one.faf/context');
+  expect(c.capabilities.extensions![0].uri).not.toContain('io.faf');
+  expect(c.capabilities.extensions![0].params).toEqual(FAFA.provenance);
 });
 
 test('no provenance → no extensions (clean omission)', () => {
   const c = fafaToA2ACard({ ...FAFA, provenance: undefined }, { url: URL });
-  expect(c.extensions).toBeUndefined();
+  expect(c.capabilities.extensions).toBeUndefined();
 });
 
 test('default I/O modes present + valid JSON-serializable', () => {
@@ -55,5 +63,5 @@ test('default I/O modes present + valid JSON-serializable', () => {
 // exists, with that endpoint's real url + tools. Identity (.fafa) ≠ hosting.
 test('mapper requires a real url to be supplied (no fabricated default)', () => {
   const c = fafaToA2ACard(FAFA, { url: URL });
-  expect(c.url).toBe(URL); // url comes from the caller (a real endpoint), never baked in
+  expect(c.supportedInterfaces[0].url).toBe(URL); // url comes from the caller, never baked in
 });


### PR DESCRIPTION
Brings the `.fafa → A2A AgentCard` mapper into **A2A v1.0 conformance**. Two related fixes, both verified against `a2aproject/A2A` `specification/a2a.proto`.

## 1. Well-known path (the original fix)
`A2A_WELL_KNOWN_PATH` + comment: `/.well-known/a2a-agent-card` → **`/.well-known/agent-card.json`** (the v1.0 discovery path).

## 2. AgentCard structure — v0.3 → v1.0 (the real bug)
The mapper emitted a **v0.3-shaped** card: top-level `url`, `protocolVersion`, and `extensions`. **A2A v1.0 restructured the AgentCard** — a v1.0 client reading the old shape **drops the top-level `url` → the agent is uncallable.** Verified against the proto (`AgentCard` / `AgentInterface` / `AgentCapabilities` / `AgentExtension`):

- `url` + `protocolVersion` fold into a **REQUIRED `supportedInterfaces[]`**, each `{ url, protocolBinding: "JSONRPC", protocolVersion: "1.0" }`.
- `extensions` move under **`capabilities.extensions[]`** (not top-level).
- Dropped the non-existent top-level `protocolVersion` / `url` / `extensions`.

This keeps the mapper output **byte-identical** with the v1.0 card FAF-Voice now serves at `/.well-known/agent-card.json` ([FAF-Voice PR #1](https://github.com/Wolfe-Jam/FAF-Voice/pull/1)) — no drift, *one context, every door*.

**Why the expanded scope:** an independent 3-pass spec review (vs the proto + `a2a-js` types) caught the v0.3/v1.0 card mismatch across both repos; fixing the path without the structure would have left a card that still fails v1.0 clients.

**Tests:** `fafa-a2a-card` **7/7 green** (assertions updated to the v1.0 shape). No other consumers of the mapper in-tree.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*