### PR TITLE
feat(fafa): source A2A card name from .fafa (displayName ?? persona ?? name)

### DIFF
--- a/src/fafa/a2a-card.ts
+++ b/src/fafa/a2a-card.ts
@@ -85,7 +85,10 @@ export function fafaToA2ACard(fafa: any, opts: { url: string }): A2AAgentCard {
     }];
   }
   return {
-    name: agent.name,
+    // Human display name, sourced from the `.fafa` — never hardcoded. Explicit
+    // `agent.displayName` wins; else the `metadata.persona`; else the machine id
+    // `agent.name`. A changeable default: set `displayName` in the `.fafa` to change it.
+    name: agent.displayName ?? fafa?.metadata?.persona ?? agent.name,
     description: agent.description,
     // v1.0: the A2A service endpoint (JSON-RPC) lives inside supportedInterfaces[].
     supportedInterfaces: [{

--- a/tests/fafa-a2a-card.test.ts
+++ b/tests/fafa-a2a-card.test.ts
@@ -26,6 +26,17 @@ test('maps required A2A v1.0 fields (supportedInterfaces, not top-level url)', (
   expect(c.capabilities.extendedAgentCard).toBe(false);
 });
 
+test('name is SOURCED, never hardcoded: displayName > metadata.persona > agent.name', () => {
+  // explicit displayName wins
+  const withDisplay = fafaToA2ACard({ ...FAFA, agent: { ...FAFA.agent, displayName: 'FAFA — the Voice of FAF' } }, { url: URL });
+  expect(withDisplay.name).toBe('FAFA — the Voice of FAF');
+  // else the persona
+  const withPersona = fafaToA2ACard({ ...FAFA, metadata: { persona: 'The Voice of FAF' } }, { url: URL });
+  expect(withPersona.name).toBe('The Voice of FAF');
+  // else the machine id (the default)
+  expect(fafaToA2ACard(FAFA, { url: URL }).name).toBe('claude-faf-mcp');
+});
+
 test('capability → skill (id/name/description/tags), count preserved', () => {
   const c = fafaToA2ACard(FAFA, { url: URL });
   expect(c.skills.length).toBe(2);


### PR DESCRIPTION
The A2A card `name` should be a **human display name**, not the machine id. The mapper now **sources** it from the `.fafa` via a fallback chain — **never hardcoded**:

```ts
name: agent.displayName ?? fafa?.metadata?.persona ?? agent.name
```

- `agent.displayName` (explicit human name) wins — see [faf-agent #4](https://github.com/Wolfe-Jam/faf-agent/pull/4) adding it.
- else `metadata.persona`, else `agent.name` (the machine id) — the **default**.
- **Changeable, not hardcoded:** set `displayName` in the `.fafa` to change it; nothing is baked into the mapper or the served card.

**Test:** `displayName > persona > name` fallback. `fafa-a2a-card` **8/8 green**.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*