### PR TITLE
docs: reword tri-sync tagline (drop "Pro feature / now free" hype)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 **FAF defines. MD instructs. AI codes.**
 
-> 🐘 **tri-sync now free for all builders** — `.faf` ↔ `CLAUDE.md` ↔ `MEMORY.md` in one command. Pro feature. Now free.
+> 🐘 **tri-sync** | `.faf` ↔ `CLAUDE.md` ↔ `MEMORY.md` in one command.
 
 > ⚡ **New: `/faf` prompt** — type `/faf` in Claude Desktop. It checks your project, scores it, drives it to 100%, and syncs. Relentlessly. One command.
 


### PR DESCRIPTION
Banner double-said "free" (`Pro feature. Now free.`). Reworded to the plain factual form:

**Before:** `🐘 **tri-sync now free for all builders** — .faf ↔ CLAUDE.md ↔ MEMORY.md in one command. Pro feature. Now free.`
**After:** `🐘 **tri-sync** | .faf ↔ CLAUDE.md ↔ MEMORY.md in one command.`

Honest pricing statements (faf.one/pro, "free for developers") left untouched. Ships with the next version bump.